### PR TITLE
Enhance reading control center

### DIFF
--- a/client/src/hooks/useReadingSettings.js
+++ b/client/src/hooks/useReadingSettings.js
@@ -7,6 +7,8 @@ const defaultSettings = {
     fontFamily: 'serif',
     lineHeight: 1.8,
     letterSpacing: 0,
+    wordSpacing: 0,
+    paragraphSpacing: 1.25,
     pageWidth: 'comfortable',
     theme: 'auto',
     textAlign: 'left',
@@ -74,9 +76,19 @@ export default function useReadingSettings() {
         fontSize: `${settings.fontSize}px`,
         lineHeight: settings.lineHeight,
         letterSpacing: `${settings.letterSpacing}em`,
+        wordSpacing: `${settings.wordSpacing}em`,
+        '--paragraph-spacing': `${settings.paragraphSpacing}em`,
         fontFamily: fontFamilyMap[settings.fontFamily] || fontFamilyMap.serif,
         textAlign: settings.textAlign,
-    }), [settings.fontSize, settings.lineHeight, settings.letterSpacing, settings.fontFamily, settings.textAlign]);
+    }), [
+        settings.fontSize,
+        settings.lineHeight,
+        settings.letterSpacing,
+        settings.wordSpacing,
+        settings.paragraphSpacing,
+        settings.fontFamily,
+        settings.textAlign,
+    ]);
 
     const contentMaxWidth = useMemo(() => widthStyleMap[settings.pageWidth] || widthStyleMap.comfortable, [settings.pageWidth]);
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -160,8 +160,8 @@ html {
 }
 
 .post-content p {
-  margin-bottom: 1.25rem;
-  line-height: 1.7;
+  margin-bottom: var(--paragraph-spacing, 1.25em);
+  line-height: inherit;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
## Summary
- add an accessible reading control panel with outside-click and escape closing plus a live preview of current settings
- introduce paragraph and word spacing controls with corresponding styling updates
- persist the new spacing preferences and expose them via the reading settings hook

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d2cf864d48832dbcc04a6d12d48c8a