### PR TITLE
Add Kindle-style margin and alignment controls

### DIFF
--- a/client/src/components/ReadingControlCenter.jsx
+++ b/client/src/components/ReadingControlCenter.jsx
@@ -1,7 +1,9 @@
 // client/src/components/ReadingControlCenter.jsx
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { HiOutlineAdjustmentsHorizontal, HiOutlineXMark, HiOutlineArrowsPointingOut } from 'react-icons/hi2';
+import { LuAlignLeft, LuAlignJustify } from 'react-icons/lu';
 import { motion, AnimatePresence, useDragControls } from 'framer-motion';
+import { marginStyleMap } from '../hooks/useReadingSettings';
 
 const themeOptions = [
     { id: 'auto', label: 'Auto', swatch: 'bg-gradient-to-r from-slate-200 via-white to-slate-200', description: 'Follow site theme' },
@@ -25,8 +27,14 @@ const widthOptions = [
 ];
 
 const alignmentOptions = [
-    { id: 'left', label: 'Left' },
-    { id: 'justify', label: 'Justify' },
+    { id: 'left', label: 'Left', description: 'Ragged right edge', Icon: LuAlignLeft },
+    { id: 'justify', label: 'Justify', description: 'Clean edges on both sides', Icon: LuAlignJustify },
+];
+
+const marginOptions = [
+    { id: 'narrow', label: 'Narrow', description: 'More words per line' },
+    { id: 'medium', label: 'Medium', description: 'Balanced reading comfort' },
+    { id: 'wide', label: 'Wide', description: 'Extra breathing room' },
 ];
 
 const themePreviewClassMap = {
@@ -78,6 +86,7 @@ export default function ReadingControlCenter({ settings, onChange, onReset }) {
         '--paragraph-spacing': `${settings.paragraphSpacing}em`,
         fontFamily: settings.fontFamily === 'mono' ? 'monospace' : settings.fontFamily === 'sans' ? 'sans-serif' : 'serif',
         filter: `brightness(${settings.brightness})`,
+        paddingInline: marginStyleMap[settings.pageMargin] || marginStyleMap.medium,
     }), [settings]);
 
     const previewThemeClass = themePreviewClassMap[settings.theme] || themePreviewClassMap.auto;
@@ -112,6 +121,16 @@ export default function ReadingControlCenter({ settings, onChange, onReset }) {
         const value = Number(event.target.value);
         onChange('brightness', clamp(Number(value.toFixed(2)), 0.6, 1.4));
     };
+
+    const handleMarginChange = (event) => {
+        const index = clamp(Number(event.target.value), 0, marginOptions.length - 1);
+        const option = marginOptions[index];
+        if (option) {
+            onChange('pageMargin', option.id);
+        }
+    };
+
+    const marginIndex = Math.max(0, marginOptions.findIndex(option => option.id === settings.pageMargin));
 
 
     return (
@@ -274,19 +293,73 @@ export default function ReadingControlCenter({ settings, onChange, onReset }) {
                                         </button>
                                     ))}
                                 </div>
+                                <div className="rounded-2xl border border-slate-200/80 dark:border-slate-700/80 p-3 space-y-3">
+                                    <div className="flex items-center justify-between text-[0.7rem] uppercase tracking-wide text-slate-400">
+                                        <span>Page margins</span>
+                                        <span className="font-semibold text-slate-500 dark:text-slate-300">{marginOptions[marginIndex]?.label || 'Medium'}</span>
+                                    </div>
+                                    <div className="flex items-center justify-between gap-2">
+                                        {marginOptions.map(option => {
+                                            const isActive = settings.pageMargin === option.id;
+                                            return (
+                                                <button
+                                                    key={option.id}
+                                                    type="button"
+                                                    onClick={() => onChange('pageMargin', option.id)}
+                                                    aria-pressed={isActive}
+                                                    className={`flex-1 rounded-xl border px-2 py-2 text-center transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                                                        isActive
+                                                            ? 'border-sky-400 bg-sky-50 text-sky-700 dark:border-sky-500 dark:bg-sky-500/10 dark:text-sky-200'
+                                                            : 'border-transparent text-slate-500 dark:text-slate-400 hover:border-sky-300/60 dark:hover:border-sky-500/60'
+                                                    }`}
+                                                >
+                                                    <div className="mx-auto mb-1 flex h-8 w-full max-w-[3.5rem] items-center justify-center rounded-lg bg-slate-200/70 dark:bg-slate-700/70">
+                                                        <div
+                                                            className={`h-6 w-full rounded-md bg-white dark:bg-slate-900 shadow-inner transition-all ${
+                                                                option.id === 'narrow'
+                                                                    ? 'mx-1'
+                                                                    : option.id === 'medium'
+                                                                        ? 'mx-2'
+                                                                        : 'mx-3'
+                                                            }`}
+                                                        ></div>
+                                                    </div>
+                                                    <p className="text-[0.65rem] font-medium">{option.label}</p>
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max={marginOptions.length - 1}
+                                        step="1"
+                                        value={marginIndex}
+                                        onChange={handleMarginChange}
+                                        className="w-full accent-sky-500"
+                                        aria-label="Adjust page margins"
+                                    />
+                                    <p className="text-[0.7rem] text-slate-500 dark:text-slate-400 text-center">
+                                        {marginOptions[marginIndex]?.description || 'Adjust the white space on either side of the page.'}
+                                    </p>
+                                </div>
                                 <div className="grid grid-cols-2 gap-2">
                                     {alignmentOptions.map(option => (
                                         <button
                                             key={option.id}
                                             type="button"
                                             onClick={() => onChange('textAlign', option.id)}
-                                            className={`rounded-2xl border px-3 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
+                                            className={`flex items-center justify-center gap-2 rounded-2xl border px-3 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${
                                                 settings.textAlign === option.id
                                                     ? 'border-sky-400 bg-sky-50 text-sky-700 dark:border-sky-500 dark:bg-sky-500/10 dark:text-sky-200'
                                                     : 'border-slate-200 hover:border-sky-300 dark:border-slate-700 dark:hover:border-sky-500'
                                             }`}
                                         >
-                                            {option.label}
+                                            <option.Icon className="h-5 w-5" aria-hidden="true" />
+                                            <span className="flex flex-col items-start leading-tight">
+                                                <span>{option.label}</span>
+                                                <span className="text-[0.6rem] font-normal text-slate-500 dark:text-slate-400">{option.description}</span>
+                                            </span>
                                         </button>
                                     ))}
                                 </div>

--- a/client/src/hooks/useReadingSettings.js
+++ b/client/src/hooks/useReadingSettings.js
@@ -3,6 +3,12 @@ import { useEffect, useMemo, useState } from 'react';
 
 const STORAGE_KEY = 'reading-preferences';
 
+export const marginStyleMap = {
+    narrow: '0.75rem',
+    medium: '1.5rem',
+    wide: '2.25rem',
+};
+
 const defaultSettings = {
     fontSize: 18,
     fontFamily: 'serif',
@@ -11,6 +17,7 @@ const defaultSettings = {
     wordSpacing: 0, // New setting
     paragraphSpacing: 1.25, // New setting
     pageWidth: 'comfortable',
+    pageMargin: 'medium',
     theme: 'auto',
     textAlign: 'left',
     brightness: 1,
@@ -76,6 +83,11 @@ export default function useReadingSettings() {
 
     const resetSettings = () => setSettings(defaultSettings);
 
+    const contentPadding = useMemo(
+        () => marginStyleMap[settings.pageMargin] || marginStyleMap.medium,
+        [settings.pageMargin]
+    );
+
     const contentStyles = useMemo(() => ({
         fontSize: `${settings.fontSize}px`,
         lineHeight: settings.lineHeight,
@@ -85,6 +97,7 @@ export default function useReadingSettings() {
         '--paragraph-spacing': `${settings.paragraphSpacing}em`, // New CSS variable for paragraph spacing
         fontFamily: fontFamilyMap[settings.fontFamily] || fontFamilyMap.serif,
         filter: `brightness(${settings.brightness})`,
+        paddingInline: contentPadding,
     }), [
         settings.fontSize,
         settings.lineHeight,
@@ -93,7 +106,8 @@ export default function useReadingSettings() {
         settings.fontFamily,
         settings.textAlign,
         settings.paragraphSpacing,
-        settings.brightness
+        settings.brightness,
+        contentPadding
     ]);
 
     const contentMaxWidth = useMemo(() => widthStyleMap[settings.pageWidth] || widthStyleMap.comfortable, [settings.pageWidth]);
@@ -112,5 +126,6 @@ export default function useReadingSettings() {
         contentStyles,
         contentMaxWidth,
         surfaceClass,
+        contentPadding,
     };
 }

--- a/client/src/pages/PostPage.jsx
+++ b/client/src/pages/PostPage.jsx
@@ -119,7 +119,16 @@ export default function PostPage() {
         contentStyles,
         contentMaxWidth,
         surfaceClass,
+        contentPadding,
     } = useReadingSettings();
+
+    const sharedContentStyle = useMemo(
+        () => ({
+            maxWidth: contentMaxWidth,
+            paddingInline: contentPadding,
+        }),
+        [contentMaxWidth, contentPadding]
+    );
 
     const openImageViewer = (index) => {
         setCurrentImage(index);
@@ -219,7 +228,7 @@ export default function PostPage() {
             <main className='p-3 flex flex-col max-w-6xl mx-auto min-h-screen'>
                 <h1
                     className='text-3xl mt-10 p-3 text-center font-serif max-w-2xl mx-auto lg:text-4xl'
-                    style={{ maxWidth: contentMaxWidth }}
+                    style={sharedContentStyle}
                 >
                     {post.title}
                 </h1>
@@ -228,13 +237,13 @@ export default function PostPage() {
                 </Link>
                 <div
                     className='mt-10 p-3 max-h-[600px] w-full flex justify-center'
-                    style={{ maxWidth: contentMaxWidth }}
+                    style={sharedContentStyle}
                 >
                     {post.mediaType === 'video' ? <video src={post.mediaUrl} controls className='w-full object-contain rounded-lg shadow-lg' /> : <img src={post.mediaUrl || post.image} alt={post.title} className='w-full object-contain rounded-lg shadow-lg' />}
                 </div>
                 <div
                     className='flex justify-between p-3 border-b border-slate-500 mx-auto w-full max-w-2xl text-xs'
-                    style={{ maxWidth: contentMaxWidth }}
+                    style={sharedContentStyle}
                 >
                     <span>{new Date(post.createdAt).toLocaleDateString("en-IN", { day: 'numeric', month: 'long', year: 'numeric' })}</span>
                     <span className='italic'>{post.content ? `${Math.ceil(post.content.split(' ').length / 200)} min read` : '0 min read'}</span>
@@ -242,7 +251,7 @@ export default function PostPage() {
 
                 <div
                     className='max-w-2xl mx-auto w-full'
-                    style={{ maxWidth: contentMaxWidth }}
+                    style={sharedContentStyle}
                 >
                     <TableOfContents headings={headings} />
                 </div>
@@ -256,7 +265,7 @@ export default function PostPage() {
 
                 <div
                     className='max-w-2xl mx-auto w-full px-3 my-8 flex justify-between items-center'
-                    style={{ maxWidth: contentMaxWidth }}
+                    style={sharedContentStyle}
                 >
                     <ClapButton post={post} />
                     <SocialShare post={post} />
@@ -264,7 +273,7 @@ export default function PostPage() {
 
                 <div
                     className='max-w-2xl mx-auto w-full'
-                    style={{ maxWidth: contentMaxWidth }}
+                    style={sharedContentStyle}
                 >
                     <CommentSection postId={post._id} />
                 </div>

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -253,7 +253,25 @@ export default function SingleTutorialPage() {
         contentStyles,
         contentMaxWidth,
         surfaceClass,
+        contentPadding,
     } = useReadingSettings();
+
+    const sharedContentStyle = useMemo(
+        () => ({
+            maxWidth: contentMaxWidth,
+            paddingInline: contentPadding,
+        }),
+        [contentMaxWidth, contentPadding]
+    );
+
+    const centeredContentStyle = useMemo(
+        () => ({
+            ...sharedContentStyle,
+            marginLeft: 'auto',
+            marginRight: 'auto',
+        }),
+        [sharedContentStyle]
+    );
 
     const findChapterBySlug = (chapters, slug) => {
         for (const chapter of chapters) {
@@ -456,20 +474,20 @@ export default function SingleTutorialPage() {
                 <main className="flex-1 p-8 overflow-x-hidden">
                     <h1
                         className='text-4xl lg:text-5xl font-extrabold text-center my-8 leading-tight text-gray-900 dark:text-white'
-                        style={{ maxWidth: contentMaxWidth, marginLeft: 'auto', marginRight: 'auto' }}
+                        style={centeredContentStyle}
                     >
                         {tutorial.title}
                     </h1>
                     <p
                         className='text-xl text-gray-600 dark:text-gray-400 text-center max-w-4xl mx-auto mb-12 font-light'
-                        style={{ maxWidth: contentMaxWidth }}
+                        style={sharedContentStyle}
                     >
                         {tutorial.description}
                     </p>
 
                     <div
                         className='flex justify-center items-center text-sm text-gray-500 dark:text-gray-400 max-w-3xl mx-auto border-b border-t py-4 mb-10 transition-all duration-300 ease-in-out'
-                        style={{ maxWidth: contentMaxWidth }}
+                        style={sharedContentStyle}
                     >
                         <div className="flex items-center mx-4">
                             <img src={author?.profilePicture || 'https://via.placeholder.com/40'} alt={author?.username} className='w-10 h-10 rounded-full object-cover mr-3 border-2 border-blue-400' />
@@ -489,7 +507,7 @@ export default function SingleTutorialPage() {
                     )}
 
                     <div className="flex flex-col lg:flex-row gap-8 max-w-6xl mx-auto">
-                        <div className="lg:w-3/4 w-full" style={{ maxWidth: contentMaxWidth }}>
+                        <div className="lg:w-3/4 w-full" style={sharedContentStyle}>
                             <h2 className='text-3xl lg:text-4xl font-bold my-6 text-gray-900 dark:text-white leading-tight'>{activeChapter.chapterTitle}</h2>
                             <ChapterContent
                                 activeChapter={activeChapter}


### PR DESCRIPTION
## Summary
- add Kindle-style margin adjustments in the Reading Control Center with slider and quick-select previews
- refresh the text alignment controls with descriptive icons and ensure the live preview reflects alignment and margin changes
- persist the new page margin preference and apply consistent horizontal padding on tutorial and post layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d3402c01f4832dbf95095b38cd6e84