### PR TITLE
feat(reader): add highlight, search, and dictionary tools

### DIFF
--- a/client/src/components/InteractiveReadingSurface.jsx
+++ b/client/src/components/InteractiveReadingSurface.jsx
@@ -1,0 +1,623 @@
+import { useState, useEffect, useMemo, useLayoutEffect, useCallback, useRef } from 'react';
+import PropTypes from 'prop-types';
+import parse from 'html-react-parser';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Spinner, Tooltip } from 'flowbite-react';
+import {
+    HiOutlineBookOpen,
+    HiOutlineSearch,
+    HiOutlineX,
+    HiOutlineChevronLeft,
+    HiOutlineChevronRight,
+    HiOutlineTrash,
+} from 'react-icons/hi';
+import { FaHighlighter } from 'react-icons/fa';
+
+const HIGHLIGHT_STORAGE_PREFIX = 'reader-highlights:';
+
+const highlightPalette = [
+    { id: 'gold', label: 'Sunbeam', className: 'reader-highlight-gold', swatch: '#facc15' },
+    { id: 'mint', label: 'Mint', className: 'reader-highlight-mint', swatch: '#34d399' },
+    { id: 'rose', label: 'Blush', className: 'reader-highlight-rose', swatch: '#fb7185' },
+    { id: 'violet', label: 'Iris', className: 'reader-highlight-violet', swatch: '#a855f7' },
+];
+
+const createStorageKey = (chapterId) => `${HIGHLIGHT_STORAGE_PREFIX}${chapterId}`;
+
+const unwrapMarks = (container, attribute) => {
+    if (!container) return;
+    const marks = container.querySelectorAll(`mark[${attribute}]`);
+    marks.forEach((mark) => {
+        const parent = mark.parentNode;
+        if (!parent) return;
+        while (mark.firstChild) {
+            parent.insertBefore(mark.firstChild, mark);
+        }
+        parent.removeChild(mark);
+    });
+};
+
+const getTextNodes = (container) => {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null);
+    const nodes = [];
+    while (walker.nextNode()) {
+        nodes.push(walker.currentNode);
+    }
+    return nodes;
+};
+
+const applyHighlightRange = (container, highlight) => {
+    if (!container || !highlight || highlight.start >= highlight.end) return;
+    const nodes = getTextNodes(container);
+    let charIndex = 0;
+    const { start, end } = highlight;
+
+    for (const node of nodes) {
+        if (!node.textContent) {
+            continue;
+        }
+
+        const length = node.textContent.length;
+        const nodeStart = charIndex;
+        const nodeEnd = charIndex + length;
+
+        if (end <= nodeStart) {
+            break;
+        }
+
+        if (start >= nodeEnd) {
+            charIndex = nodeEnd;
+            continue;
+        }
+
+        const localStart = Math.max(0, start - nodeStart);
+        const localEnd = Math.min(length, end - nodeStart);
+
+        if (localStart === localEnd) {
+            charIndex = nodeEnd;
+            continue;
+        }
+
+        const range = document.createRange();
+        range.setStart(node, localStart);
+        range.setEnd(node, localEnd);
+        const mark = document.createElement('mark');
+        mark.dataset.readerHighlight = 'true';
+        mark.dataset.highlightId = highlight.id;
+        mark.dataset.highlightColor = highlight.color;
+        mark.className = `reader-highlight ${highlightPalette.find((c) => c.id === highlight.color)?.className || ''}`;
+        mark.appendChild(range.extractContents());
+        range.insertNode(mark);
+        range.detach();
+
+        if (end <= nodeEnd) {
+            break;
+        }
+
+        charIndex = nodeEnd;
+    }
+};
+
+const applySearchHighlights = (container, term, activeIndex) => {
+    if (!container || !term) return [];
+    const searchTerm = term.trim();
+    if (!searchTerm) return [];
+
+    const lowerTerm = searchTerm.toLowerCase();
+    const results = [];
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null);
+
+    let matchIndex = 0;
+
+    while (walker.nextNode()) {
+        let node = walker.currentNode;
+        if (!node || !node.textContent) continue;
+        if (node.parentElement?.closest('mark[data-reader-highlight], mark[data-search-hit]')) {
+            continue;
+        }
+
+        let text = node.textContent;
+        let searchStart = 0;
+
+        while (text) {
+            const foundIndex = text.toLowerCase().indexOf(lowerTerm, searchStart);
+            if (foundIndex === -1) break;
+
+            const range = document.createRange();
+            range.setStart(node, foundIndex);
+            range.setEnd(node, foundIndex + searchTerm.length);
+
+            const mark = document.createElement('mark');
+            mark.dataset.searchHit = 'true';
+            mark.dataset.searchIndex = `${matchIndex}`;
+            mark.className = 'reader-search-highlight';
+            mark.appendChild(range.extractContents());
+            range.insertNode(mark);
+            range.detach();
+
+            if (matchIndex === activeIndex) {
+                mark.classList.add('reader-search-highlight-active');
+                mark.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+            }
+
+            results.push({ index: matchIndex, text: mark.textContent });
+            matchIndex += 1;
+
+            const nextNode = mark.nextSibling;
+            if (nextNode && nextNode.nodeType === Node.TEXT_NODE) {
+                node = nextNode;
+                text = node.textContent;
+                searchStart = 0;
+            } else {
+                break;
+            }
+        }
+    }
+
+    return results;
+};
+
+const getSelectionOffsets = (container, range) => {
+    const preRange = range.cloneRange();
+    preRange.selectNodeContents(container);
+    preRange.setEnd(range.startContainer, range.startOffset);
+    const start = preRange.toString().length;
+    const end = start + range.toString().length;
+    preRange.detach();
+    return { start, end };
+};
+
+const InteractiveReadingSurface = ({
+    content,
+    parserOptions,
+    contentStyles,
+    contentMaxWidth,
+    surfaceClass,
+    className,
+    chapterId,
+}) => {
+    const containerRef = useRef(null);
+    const [highlights, setHighlights] = useState([]);
+    const [selectionMenu, setSelectionMenu] = useState(null);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [searchMatches, setSearchMatches] = useState([]);
+    const [activeMatchIndex, setActiveMatchIndex] = useState(0);
+    const [dictionaryState, setDictionaryState] = useState({
+        word: '',
+        loading: false,
+        entries: [],
+        error: null,
+        open: false,
+    });
+
+    const parsedContent = useMemo(() => parse(content || '', parserOptions), [content, parserOptions]);
+
+    useEffect(() => {
+        if (!chapterId || typeof window === 'undefined') {
+            setHighlights([]);
+            return;
+        }
+
+        try {
+            const stored = localStorage.getItem(createStorageKey(chapterId));
+            if (stored) {
+                const parsed = JSON.parse(stored);
+                if (Array.isArray(parsed)) {
+                    setHighlights(parsed);
+                    return;
+                }
+            }
+        } catch (error) {
+            console.error('Failed to load highlights for chapter', error);
+        }
+        setHighlights([]);
+    }, [chapterId, content]);
+
+    useEffect(() => {
+        if (!chapterId || typeof window === 'undefined') return;
+        try {
+            localStorage.setItem(createStorageKey(chapterId), JSON.stringify(highlights));
+        } catch (error) {
+            console.error('Failed to persist highlights', error);
+        }
+    }, [chapterId, highlights]);
+
+    useEffect(() => {
+        setSearchTerm('');
+        setSearchMatches([]);
+        setActiveMatchIndex(0);
+        setSelectionMenu(null);
+    }, [chapterId, content]);
+
+    useLayoutEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        unwrapMarks(container, 'data-reader-highlight');
+        unwrapMarks(container, 'data-search-hit');
+
+        const ordered = [...highlights].sort((a, b) => a.start - b.start);
+        ordered.forEach((highlight) => applyHighlightRange(container, { ...highlight }));
+
+        if (searchTerm) {
+            const matches = applySearchHighlights(container, searchTerm, activeMatchIndex);
+            setSearchMatches(matches);
+        } else {
+            setSearchMatches([]);
+        }
+    }, [content, highlights, searchTerm, activeMatchIndex]);
+
+    useEffect(() => {
+        if (searchMatches.length === 0 && activeMatchIndex !== 0) {
+            setActiveMatchIndex(0);
+        }
+        if (searchMatches.length > 0 && activeMatchIndex >= searchMatches.length) {
+            setActiveMatchIndex(searchMatches.length - 1);
+        }
+    }, [searchMatches, activeMatchIndex]);
+
+    const closeSelectionMenu = useCallback(() => {
+        setSelectionMenu(null);
+    }, []);
+
+    const captureSelection = useCallback(() => {
+        const container = containerRef.current;
+        if (!container) return;
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) {
+            closeSelectionMenu();
+            return;
+        }
+
+        const range = selection.getRangeAt(0);
+        if (!container.contains(range.commonAncestorContainer)) {
+            closeSelectionMenu();
+            return;
+        }
+
+        const text = selection.toString().trim();
+        if (!text) {
+            closeSelectionMenu();
+            return;
+        }
+
+        const { start, end } = getSelectionOffsets(container, range);
+        if (start === end) {
+            closeSelectionMenu();
+            return;
+        }
+
+        const rect = range.getBoundingClientRect();
+        const existing = highlights.find((item) => start >= item.start && end <= item.end);
+
+        setSelectionMenu({
+            text,
+            start,
+            end,
+            highlightId: existing?.id || null,
+            color: existing?.color || null,
+            position: {
+                x: rect.left + window.scrollX + rect.width / 2,
+                y: rect.top + window.scrollY - 12,
+            },
+        });
+    }, [closeSelectionMenu, highlights]);
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        const handleMouseUp = () => setTimeout(captureSelection, 0);
+        const handleTouchEnd = () => setTimeout(captureSelection, 0);
+        const handleKeyUp = () => setTimeout(captureSelection, 0);
+        const handleScroll = () => closeSelectionMenu();
+        const handleDocumentClick = (event) => {
+            if (!selectionMenu) return;
+            if (!container.contains(event.target)) {
+                closeSelectionMenu();
+            }
+        };
+
+        container.addEventListener('mouseup', handleMouseUp);
+        container.addEventListener('touchend', handleTouchEnd);
+        container.addEventListener('keyup', handleKeyUp);
+        document.addEventListener('scroll', handleScroll, true);
+        document.addEventListener('mousedown', handleDocumentClick);
+
+        return () => {
+            container.removeEventListener('mouseup', handleMouseUp);
+            container.removeEventListener('touchend', handleTouchEnd);
+            container.removeEventListener('keyup', handleKeyUp);
+            document.removeEventListener('scroll', handleScroll, true);
+            document.removeEventListener('mousedown', handleDocumentClick);
+        };
+    }, [captureSelection, closeSelectionMenu, selectionMenu]);
+
+    const handleAddHighlight = (color) => {
+        if (!selectionMenu) return;
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) return;
+        const range = selection.getRangeAt(0);
+        if (!range || range.toString().trim().length === 0) return;
+
+        const { start, end } = selectionMenu;
+        const text = range.toString();
+        const id = typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `hl-${Date.now()}`;
+
+        setHighlights((prev) => {
+            const filtered = prev.filter((item) => item.id !== selectionMenu.highlightId);
+            return [...filtered, { id, start, end, color, text }];
+        });
+        setSelectionMenu(null);
+        selection.removeAllRanges();
+    };
+
+    const handleRemoveHighlight = (id) => {
+        setHighlights((prev) => prev.filter((item) => item.id !== id));
+        setSelectionMenu(null);
+    };
+
+    const handleLookupWord = async (text) => {
+        if (!text) return;
+        const word = text.split(/\s+/)[0].toLowerCase();
+        setDictionaryState({ word, loading: true, entries: [], error: null, open: true });
+        try {
+            const response = await fetch(`https://api.dictionaryapi.dev/api/v2/entries/en/${encodeURIComponent(word)}`);
+            if (!response.ok) {
+                throw new Error('Definition not found for selected term.');
+            }
+            const data = await response.json();
+            setDictionaryState({ word, loading: false, entries: data, error: null, open: true });
+        } catch (error) {
+            setDictionaryState({
+                word,
+                loading: false,
+                entries: [],
+                error: error.message || 'Unable to fetch dictionary entry.',
+                open: true,
+            });
+        }
+    };
+
+    const handleSearchChange = (event) => {
+        setSearchTerm(event.target.value);
+        setActiveMatchIndex(0);
+    };
+
+    const goToNextMatch = () => {
+        if (searchMatches.length === 0) return;
+        setActiveMatchIndex((prev) => (prev + 1) % searchMatches.length);
+    };
+
+    const goToPreviousMatch = () => {
+        if (searchMatches.length === 0) return;
+        setActiveMatchIndex((prev) => (prev - 1 + searchMatches.length) % searchMatches.length);
+    };
+
+    const clearSearch = () => {
+        setSearchTerm('');
+        setActiveMatchIndex(0);
+    };
+
+    const closeDictionary = () => {
+        setDictionaryState((prev) => ({ ...prev, open: false }));
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="reader-utility-bar">
+                <div className="reader-search-field">
+                    <HiOutlineSearch className="reader-search-icon" aria-hidden />
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={handleSearchChange}
+                        placeholder="Search within this chapter..."
+                        className="reader-search-input"
+                    />
+                    {searchTerm && (
+                        <button type="button" className="reader-search-clear" onClick={clearSearch} aria-label="Clear search">
+                            <HiOutlineX />
+                        </button>
+                    )}
+                </div>
+                {searchMatches.length > 0 && (
+                    <div className="reader-search-controls">
+                        <button type="button" onClick={goToPreviousMatch} aria-label="Previous match">
+                            <HiOutlineChevronLeft />
+                        </button>
+                        <span>
+                            {activeMatchIndex + 1} / {searchMatches.length}
+                        </span>
+                        <button type="button" onClick={goToNextMatch} aria-label="Next match">
+                            <HiOutlineChevronRight />
+                        </button>
+                    </div>
+                )}
+            </div>
+
+            <motion.div
+                ref={containerRef}
+                className={`${className} ${surfaceClass}`.trim()}
+                data-reading-surface="true"
+                style={{ ...contentStyles, maxWidth: contentMaxWidth }}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+                tabIndex={0}
+            >
+                {parsedContent}
+            </motion.div>
+
+            {highlights.length > 0 && (
+                <div className="reader-highlights-panel">
+                    <div className="reader-highlights-header">
+                        <div className="flex items-center gap-2">
+                            <FaHighlighter aria-hidden />
+                            <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">Your Highlights</h3>
+                        </div>
+                        <button
+                            type="button"
+                            className="reader-highlight-clear"
+                            onClick={() => setHighlights([])}
+                        >
+                            <HiOutlineTrash className="mr-1" /> Clear all
+                        </button>
+                    </div>
+                    <ul className="space-y-3">
+                        {highlights
+                            .slice()
+                            .sort((a, b) => a.start - b.start)
+                            .map((highlight) => (
+                                <li key={highlight.id} className="reader-highlight-item">
+                                    <span className={`reader-highlight-chip ${highlightPalette.find((c) => c.id === highlight.color)?.className || ''}`}>
+                                        {highlight.text.trim().slice(0, 120)}
+                                        {highlight.text.length > 120 ? '…' : ''}
+                                    </span>
+                                    <div className="flex items-center gap-2">
+                                        <Tooltip content="Reveal highlight">
+                                            <button
+                                                type="button"
+                                                className="reader-highlight-jump"
+                                                onClick={() => {
+                                                    const container = containerRef.current;
+                                                    if (!container) return;
+                                                    const mark = container.querySelector(`mark[data-highlight-id="${highlight.id}"]`);
+                                                    if (mark) {
+                                                        mark.classList.add('reader-highlight-pulse');
+                                                        mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                                                        setTimeout(() => mark.classList.remove('reader-highlight-pulse'), 1200);
+                                                    }
+                                                }}
+                                            >
+                                                Jump
+                                            </button>
+                                        </Tooltip>
+                                        <button
+                                            type="button"
+                                            className="reader-highlight-delete"
+                                            onClick={() => handleRemoveHighlight(highlight.id)}
+                                        >
+                                            Remove
+                                        </button>
+                                    </div>
+                                </li>
+                            ))}
+                    </ul>
+                </div>
+            )}
+
+            <AnimatePresence>
+                {dictionaryState.open && (
+                    <motion.div
+                        key="dictionary"
+                        className="reader-dictionary-panel"
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: 10 }}
+                    >
+                        <div className="reader-dictionary-header">
+                            <div className="flex items-center gap-2">
+                                <HiOutlineBookOpen aria-hidden />
+                                <h4 className="text-sm font-semibold">Dictionary · {dictionaryState.word}</h4>
+                            </div>
+                            <button type="button" onClick={closeDictionary} aria-label="Close dictionary">
+                                <HiOutlineX />
+                            </button>
+                        </div>
+                        <div className="reader-dictionary-body">
+                            {dictionaryState.loading && (
+                                <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-300">
+                                    <Spinner size="sm" />
+                                    <span>Looking up definition…</span>
+                                </div>
+                            )}
+                            {!dictionaryState.loading && dictionaryState.error && (
+                                <p className="text-sm text-red-500">{dictionaryState.error}</p>
+                            )}
+                            {!dictionaryState.loading && !dictionaryState.error && dictionaryState.entries.length > 0 && (
+                                <div className="space-y-3 text-sm">
+                                    {dictionaryState.entries[0]?.meanings?.slice(0, 2).map((meaning, index) => (
+                                        <div key={index} className="reader-dictionary-meaning">
+                                            <p className="font-semibold text-slate-700 dark:text-slate-200">
+                                                {meaning.partOfSpeech}
+                                            </p>
+                                            <ul className="list-disc pl-5 text-slate-600 dark:text-slate-300">
+                                                {meaning.definitions.slice(0, 2).map((def, defIndex) => (
+                                                    <li key={defIndex}>{def.definition}</li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {selectionMenu && typeof document !== 'undefined' &&
+                createPortal(
+                    <AnimatePresence>
+                        <motion.div
+                            key="selection-menu"
+                            className="reader-selection-menu"
+                            initial={{ opacity: 0, scale: 0.95 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            exit={{ opacity: 0, scale: 0.95 }}
+                            style={{ top: selectionMenu.position.y, left: selectionMenu.position.x }}
+                        >
+                            <div className="reader-selection-card">
+                                <p className="reader-selection-text">{selectionMenu.text.slice(0, 80)}{selectionMenu.text.length > 80 ? '…' : ''}</p>
+                                <div className="reader-selection-actions">
+                                    {highlightPalette.map((item) => (
+                                        <button
+                                            key={item.id}
+                                            type="button"
+                                            className={`reader-highlight-option ${selectionMenu.color === item.id ? 'active' : ''}`}
+                                            onClick={() => handleAddHighlight(item.id)}
+                                            style={{ '--highlight-swatch': item.swatch }}
+                                        >
+                                            <FaHighlighter aria-hidden />
+                                        </button>
+                                    ))}
+                                    <button
+                                        type="button"
+                                        className="reader-selection-button"
+                                        onClick={() => handleLookupWord(selectionMenu.text)}
+                                        aria-label="Look up in dictionary"
+                                    >
+                                        <HiOutlineBookOpen />
+                                    </button>
+                                    {selectionMenu.highlightId && (
+                                        <button
+                                            type="button"
+                                            className="reader-selection-button"
+                                            onClick={() => handleRemoveHighlight(selectionMenu.highlightId)}
+                                            aria-label="Remove highlight"
+                                        >
+                                            <HiOutlineTrash />
+                                        </button>
+                                    )}
+                                </div>
+                            </div>
+                        </motion.div>
+                    </AnimatePresence>,
+                    document.body
+                )}
+        </div>
+    );
+};
+
+InteractiveReadingSurface.propTypes = {
+    content: PropTypes.string,
+    parserOptions: PropTypes.object,
+    contentStyles: PropTypes.object,
+    contentMaxWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    surfaceClass: PropTypes.string,
+    className: PropTypes.string,
+    chapterId: PropTypes.string,
+};
+
+export default InteractiveReadingSurface;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -202,6 +202,379 @@ html {
   margin-bottom: 0.5rem;
 }
 
+/*
+ * ========================================
+ * Advanced Reading Experience Enhancements
+ * ========================================
+ */
+
+.reader-utility-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(56, 189, 248, 0.08));
+  border: 1px solid rgba(59, 130, 246, 0.12);
+}
+
+.dark .reader-utility-bar {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(14, 165, 233, 0.18));
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.reader-search-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  gap: 0.5rem;
+}
+
+.reader-search-icon {
+  position: absolute;
+  left: 0.75rem;
+  font-size: 1rem;
+  color: rgba(71, 85, 105, 0.7);
+}
+
+.dark .reader-search-icon {
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.reader-search-input {
+  width: 100%;
+  padding: 0.6rem 2.5rem 0.6rem 2.2rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background-color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.reader-search-input:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.dark .reader-search-input {
+  background-color: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+}
+
+.reader-search-clear {
+  position: absolute;
+  right: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  background: rgba(15, 118, 110, 0.1);
+  color: rgba(15, 118, 110, 0.9);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.reader-search-clear:hover {
+  background: rgba(15, 118, 110, 0.2);
+}
+
+.reader-search-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 9999px;
+  background: rgba(59, 130, 246, 0.1);
+  font-size: 0.85rem;
+  color: #1e3a8a;
+}
+
+.reader-search-controls button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  transition: background 0.2s ease;
+}
+
+.reader-search-controls button:hover {
+  background: rgba(59, 130, 246, 0.18);
+}
+
+.dark .reader-search-controls {
+  background: rgba(96, 165, 250, 0.15);
+  color: #bfdbfe;
+}
+
+.reader-highlight {
+  border-radius: 0.35rem;
+  padding: 0.05rem 0.25rem;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.reader-highlight-gold {
+  background: rgba(252, 211, 77, 0.7);
+  color: #7c2d12;
+}
+
+.reader-highlight-mint {
+  background: rgba(110, 231, 183, 0.6);
+  color: #064e3b;
+}
+
+.reader-highlight-rose {
+  background: rgba(252, 165, 165, 0.6);
+  color: #9f1239;
+}
+
+.reader-highlight-violet {
+  background: rgba(196, 181, 253, 0.6);
+  color: #5b21b6;
+}
+
+.reader-highlight-pulse {
+  animation: readerHighlightPulse 1.2s ease;
+}
+
+@keyframes readerHighlightPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4);
+  }
+  100% {
+    box-shadow: 0 0 0 12px rgba(59, 130, 246, 0);
+  }
+}
+
+.reader-highlights-panel {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.9rem;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(8px);
+}
+
+.dark .reader-highlights-panel {
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.3);
+}
+
+.reader-highlights-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.reader-highlight-clear {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+  transition: background 0.2s ease;
+}
+
+.reader-highlight-clear:hover {
+  background: rgba(248, 113, 113, 0.25);
+}
+
+.reader-highlight-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reader-highlight-chip {
+  flex: 1;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.reader-highlight-jump,
+.reader-highlight-delete {
+  font-size: 0.8rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  transition: all 0.2s ease;
+}
+
+.reader-highlight-jump:hover,
+.reader-highlight-delete:hover {
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.reader-highlight-delete {
+  border-color: rgba(244, 63, 94, 0.35);
+  color: rgba(190, 18, 60, 0.9);
+}
+
+.reader-search-highlight {
+  background: rgba(59, 130, 246, 0.2);
+  border-bottom: 2px solid rgba(37, 99, 235, 0.4);
+}
+
+.reader-search-highlight-active {
+  background: rgba(191, 219, 254, 0.9);
+  border-bottom-color: rgba(29, 78, 216, 0.75);
+}
+
+.dark .reader-search-highlight {
+  background: rgba(96, 165, 250, 0.25);
+  border-bottom-color: rgba(59, 130, 246, 0.5);
+}
+
+.dark .reader-search-highlight-active {
+  background: rgba(37, 99, 235, 0.45);
+  border-bottom-color: rgba(29, 78, 216, 0.7);
+}
+
+.reader-dictionary-panel {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(8px);
+  padding: 1rem 1.25rem;
+  box-shadow: 0 10px 30px -15px rgba(15, 23, 42, 0.25);
+}
+
+.dark .reader-dictionary-panel {
+  background: rgba(15, 23, 42, 0.85);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.reader-dictionary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+  color: #1e293b;
+}
+
+.dark .reader-dictionary-header {
+  color: #e2e8f0;
+}
+
+.reader-dictionary-header button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  transition: background 0.2s ease;
+}
+
+.reader-dictionary-header button:hover {
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.reader-dictionary-body {
+  color: rgba(51, 65, 85, 0.9);
+}
+
+.dark .reader-dictionary-body {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.reader-dictionary-meaning ul {
+  margin-top: 0.35rem;
+}
+
+.reader-selection-menu {
+  position: absolute;
+  transform: translate(-50%, -110%);
+  z-index: 60;
+}
+
+.reader-selection-card {
+  min-width: 240px;
+  max-width: 320px;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 32px -18px rgba(30, 64, 175, 0.35);
+  padding: 0.9rem 1rem;
+}
+
+.dark .reader-selection-card {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.reader-selection-text {
+  font-size: 0.8rem;
+  color: rgba(30, 64, 175, 0.9);
+  margin-bottom: 0.65rem;
+}
+
+.dark .reader-selection-text {
+  color: rgba(191, 219, 254, 0.85);
+}
+
+.reader-selection-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.reader-highlight-option,
+.reader-selection-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.9);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.reader-highlight-option:hover,
+.reader-selection-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.55);
+}
+
+.reader-highlight-option {
+  position: relative;
+  color: rgba(30, 64, 175, 0.9);
+}
+
+.reader-highlight-option::after {
+  content: '';
+  position: absolute;
+  inset: 0.3rem;
+  border-radius: 9999px;
+  background: var(--highlight-swatch);
+  opacity: 0.75;
+  z-index: -1;
+}
+
+.reader-highlight-option.active {
+  border-color: rgba(59, 130, 246, 0.7);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.dark .reader-highlight-option,
+.dark .reader-selection-button {
+  background: rgba(30, 41, 59, 0.9);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.9);
+}
+
 .post-content ol li {
   list-style-type: decimal;
   margin-bottom: 0.5rem;

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { getTutorials } from '../services/tutorialService';
 import { Spinner, Alert, Button, Progress } from 'flowbite-react';
 import DOMPurify from 'dompurify';
-import parse from 'html-react-parser';
 import { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useSelector } from 'react-redux';
@@ -19,6 +18,7 @@ import CommentSection from '../components/CommentSection';
 import CodeEditor from '../components/CodeEditor';
 import QuizComponent from '../components/QuizComponent';
 import InteractiveCodeBlock from '../components/InteractiveCodeBlock.jsx';
+import InteractiveReadingSurface from '../components/InteractiveReadingSurface.jsx';
 import ReadingControlCenter from '../components/ReadingControlCenter';
 import useReadingSettings from '../hooks/useReadingSettings';
 
@@ -127,20 +127,16 @@ const ChapterContent = ({ activeChapter, sanitizedContent, parserOptions, conten
             );
         case 'text':
         default:
-            // Renders standard text content from the Tiptap editor.
             return (
-                <motion.div
-                    key="text-content"
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -20 }}
-                    transition={{ duration: 0.4 }}
-                    className={`${readingClassName} p-3 mx-auto leading-relaxed text-lg text-gray-700 dark:text-gray-300`}
-                    data-reading-surface="true"
-                    style={readingStyle}
-                >
-                    {parse(sanitizedContent, parserOptions)}
-                </motion.div>
+                <InteractiveReadingSurface
+                    content={sanitizedContent}
+                    parserOptions={parserOptions}
+                    contentStyles={contentStyles}
+                    contentMaxWidth={contentMaxWidth}
+                    surfaceClass={surfaceClass}
+                    className='post-content tiptap reading-surface transition-all duration-300 p-3 mx-auto leading-relaxed text-lg text-gray-700 dark:text-gray-300'
+                    chapterId={activeChapter?._id}
+                />
             );
     }
 };


### PR DESCRIPTION
## Summary
- introduce an interactive reading surface that supports persistent highlights, contextual dictionary lookups, and in-chapter search with match navigation
- wire tutorial chapters to use the new reading surface for text-based lessons
- add styling for reader utilities, highlight palettes, dictionary drawers, and floating selection controls

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d35044a22c832da21a913fa021d6b9