### PR TITLE
feat(reader): add advanced selection controls

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -529,6 +529,160 @@ html {
   gap: 0.5rem;
 }
 
+.reader-selection-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.reader-selection-section:last-of-type {
+  margin-bottom: 0;
+}
+
+.reader-selection-section-title {
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.dark .reader-selection-section-title {
+  color: rgba(203, 213, 225, 0.8);
+}
+
+.reader-selection-range-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.reader-selection-handle-group {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.reader-selection-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.9);
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  color: rgba(30, 41, 59, 0.85);
+}
+
+.reader-selection-handle:hover {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.55);
+  background: rgba(219, 234, 254, 0.6);
+}
+
+.dark .reader-selection-handle {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.reader-selection-scope {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.reader-selection-scope button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(241, 245, 249, 0.85);
+  color: rgba(30, 41, 59, 0.85);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.reader-selection-scope button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.55);
+  background: rgba(219, 234, 254, 0.7);
+}
+
+.dark .reader-selection-scope button {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(100, 116, 139, 0.5);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.reader-selection-scope button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.reader-selection-quick {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.reader-selection-quick button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.72rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.9);
+  color: rgba(30, 41, 59, 0.9);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.reader-selection-quick button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.55);
+  background: rgba(219, 234, 254, 0.7);
+}
+
+.reader-selection-quick button span {
+  font-weight: 600;
+}
+
+.reader-selection-quick button.active {
+  border-color: rgba(30, 144, 255, 0.65);
+  background: rgba(191, 219, 254, 0.65);
+  color: rgba(30, 64, 175, 0.95);
+}
+
+.dark .reader-selection-quick button {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(100, 116, 139, 0.5);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.dark .reader-selection-quick button.active {
+  border-color: rgba(96, 165, 250, 0.6);
+  background: rgba(37, 99, 235, 0.45);
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.reader-selection-feedback {
+  font-size: 0.7rem;
+  color: rgba(30, 64, 175, 0.85);
+  margin-top: 0.25rem;
+}
+
+.dark .reader-selection-feedback {
+  color: rgba(191, 219, 254, 0.85);
+}
+
 .reader-highlight-option,
 .reader-selection-button {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- enhance the interactive reader with offset-aware helpers to rebuild selections, smart sentence/paragraph expansion, and range adjustment utilities
- expand the floating selection menu with Kindle-style controls for trimming/expanding, sentence and paragraph capture, and quick actions to copy, share, or read the passage aloud
- refresh reader selection styling to accommodate the new sections, handle groups, quick action pills, and inline feedback messaging for light and dark themes

## Testing
- npx eslint src/components/InteractiveReadingSurface.jsx

------
https://chatgpt.com/codex/tasks/task_b_68d35ff6732c832d9e2a24e67b220082