### PR TITLE
Redesign reader selection popover

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -492,241 +492,201 @@ html {
   margin-top: 0.35rem;
 }
 
+
 .reader-selection-menu {
   position: absolute;
-  transform: translate(-50%, -110%);
+  transform: translate(-50%, -120%);
   z-index: 60;
+  pointer-events: none;
 }
 
-.reader-selection-card {
-  min-width: 240px;
-  max-width: 320px;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(59, 130, 246, 0.2);
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 12px 32px -18px rgba(30, 64, 175, 0.35);
-  padding: 0.9rem 1rem;
-}
-
-.dark .reader-selection-card {
-  background: rgba(15, 23, 42, 0.9);
-  border-color: rgba(148, 163, 184, 0.35);
-}
-
-.reader-selection-text {
-  font-size: 0.8rem;
-  color: rgba(30, 64, 175, 0.9);
-  margin-bottom: 0.65rem;
-}
-
-.dark .reader-selection-text {
-  color: rgba(191, 219, 254, 0.85);
-}
-
-.reader-selection-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.reader-selection-section {
+.reader-selection-popover {
+  pointer-events: auto;
+  min-width: 220px;
+  max-width: 300px;
+  border-radius: 1.15rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 18px 45px -20px rgba(30, 64, 175, 0.35);
+  backdrop-filter: blur(14px);
+  padding: 0.85rem 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  margin-bottom: 0.75rem;
+  gap: 0.65rem;
 }
 
-.reader-selection-section:last-of-type {
-  margin-bottom: 0;
+.dark .reader-selection-popover {
+  background: rgba(15, 23, 42, 0.92);
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: 0 18px 45px -20px rgba(2, 6, 23, 0.65);
 }
 
-.reader-selection-section-title {
-  font-size: 0.65rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-weight: 600;
-  color: rgba(71, 85, 105, 0.85);
-}
-
-.dark .reader-selection-section-title {
-  color: rgba(203, 213, 225, 0.8);
-}
-
-.reader-selection-range-controls {
+.reader-selection-top {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.reader-selection-handle-group {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.reader-selection-handle {
+.reader-highlight-button {
+  flex: 1 1 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(248, 250, 252, 0.9);
-  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-  color: rgba(30, 41, 59, 0.85);
-}
-
-.reader-selection-handle:hover {
-  transform: translateY(-1px);
-  border-color: rgba(59, 130, 246, 0.55);
-  background: rgba(219, 234, 254, 0.6);
-}
-
-.dark .reader-selection-handle {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(148, 163, 184, 0.35);
-  color: rgba(226, 232, 240, 0.85);
-}
-
-.reader-selection-scope {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.reader-selection-scope button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.7rem;
-  padding: 0.3rem 0.65rem;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 9999px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(241, 245, 249, 0.85);
-  color: rgba(30, 41, 59, 0.85);
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  background: linear-gradient(135deg, rgba(254, 240, 138, 0.98), rgba(250, 204, 21, 0.9));
+  color: rgba(146, 64, 14, 0.92);
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: 0 12px 28px -18px rgba(245, 158, 11, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
-.reader-selection-scope button:hover {
+.reader-highlight-button:hover {
   transform: translateY(-1px);
-  border-color: rgba(59, 130, 246, 0.55);
-  background: rgba(219, 234, 254, 0.7);
+  box-shadow: 0 16px 32px -20px rgba(245, 158, 11, 0.65);
 }
 
-.dark .reader-selection-scope button {
-  background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(100, 116, 139, 0.5);
-  color: rgba(226, 232, 240, 0.85);
+.reader-highlight-button.is-active {
+  background: rgba(252, 211, 77, 0.18);
+  color: rgba(146, 64, 14, 0.92);
+  box-shadow: none;
 }
 
-.reader-selection-scope button svg {
-  width: 1rem;
-  height: 1rem;
+.dark .reader-highlight-button {
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.35), rgba(250, 204, 21, 0.3));
+  color: rgba(253, 230, 138, 0.95);
+  border-color: rgba(245, 158, 11, 0.35);
+  box-shadow: 0 12px 28px -20px rgba(245, 158, 11, 0.35);
 }
 
-.reader-selection-quick {
+.dark .reader-highlight-button.is-active {
+  background: rgba(120, 53, 15, 0.35);
+  color: rgba(253, 230, 138, 0.95);
+}
+
+.reader-selection-icons {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.reader-selection-quick button {
-  display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.35rem 0.65rem;
-  font-size: 0.72rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(248, 250, 252, 0.9);
-  color: rgba(30, 41, 59, 0.9);
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
-.reader-selection-quick button:hover {
+.reader-selection-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(241, 245, 249, 0.9);
+  color: rgba(30, 41, 59, 0.85);
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.reader-selection-icon:hover {
   transform: translateY(-1px);
   border-color: rgba(59, 130, 246, 0.55);
-  background: rgba(219, 234, 254, 0.7);
+  background: rgba(219, 234, 254, 0.75);
+  color: rgba(30, 64, 175, 0.9);
 }
 
-.reader-selection-quick button span {
-  font-weight: 600;
-}
-
-.reader-selection-quick button.active {
-  border-color: rgba(30, 144, 255, 0.65);
-  background: rgba(191, 219, 254, 0.65);
+.reader-selection-icon.active {
+  border-color: rgba(59, 130, 246, 0.65);
+  background: rgba(191, 219, 254, 0.7);
   color: rgba(30, 64, 175, 0.95);
+  box-shadow: 0 0 0 2px rgba(191, 219, 254, 0.45);
 }
 
-.dark .reader-selection-quick button {
+.dark .reader-selection-icon {
   background: rgba(30, 41, 59, 0.85);
-  border-color: rgba(100, 116, 139, 0.5);
-  color: rgba(226, 232, 240, 0.85);
+  border-color: rgba(100, 116, 139, 0.45);
+  color: rgba(226, 232, 240, 0.9);
 }
 
-.dark .reader-selection-quick button.active {
+.dark .reader-selection-icon:hover {
   border-color: rgba(96, 165, 250, 0.6);
-  background: rgba(37, 99, 235, 0.45);
+  background: rgba(30, 64, 175, 0.35);
   color: rgba(191, 219, 254, 0.95);
 }
 
+.dark .reader-selection-icon.active {
+  border-color: rgba(96, 165, 250, 0.75);
+  background: rgba(30, 64, 175, 0.45);
+  color: rgba(191, 219, 254, 0.95);
+  box-shadow: 0 0 0 2px rgba(30, 64, 175, 0.35);
+}
+
+.reader-highlight-palette {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.55rem;
+  border-radius: 0.95rem;
+  background: rgba(148, 163, 184, 0.16);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.dark .reader-highlight-palette {
+  background: rgba(51, 65, 85, 0.5);
+  border-color: rgba(100, 116, 139, 0.45);
+}
+
+.reader-highlight-swatch {
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background: var(--highlight-swatch);
+  box-shadow: 0 6px 14px -10px rgba(15, 23, 42, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.reader-highlight-swatch:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px -12px rgba(15, 23, 42, 0.45);
+}
+
+.reader-highlight-swatch.active {
+  border-color: rgba(59, 130, 246, 0.7);
+  box-shadow: 0 0 0 3px rgba(191, 219, 254, 0.55);
+}
+
+.dark .reader-highlight-swatch {
+  box-shadow: 0 6px 14px -10px rgba(2, 6, 23, 0.55);
+}
+
+.dark .reader-highlight-swatch.active {
+  border-color: rgba(191, 219, 254, 0.75);
+  box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.45);
+}
+
+.reader-selection-snippet {
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: rgba(51, 65, 85, 0.9);
+  background: rgba(248, 250, 252, 0.85);
+  border-radius: 0.95rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.6rem 0.75rem;
+}
+
+.dark .reader-selection-snippet {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(71, 85, 105, 0.45);
+  color: rgba(226, 232, 240, 0.88);
+}
+
 .reader-selection-feedback {
-  font-size: 0.7rem;
-  color: rgba(30, 64, 175, 0.85);
-  margin-top: 0.25rem;
+  font-size: 0.72rem;
+  color: rgba(37, 99, 235, 0.85);
 }
 
 .dark .reader-selection-feedback {
-  color: rgba(191, 219, 254, 0.85);
-}
-
-.reader-highlight-option,
-.reader-selection-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 9999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(248, 250, 252, 0.9);
-  transition: transform 0.2s ease, border-color 0.2s ease;
-}
-
-.reader-highlight-option:hover,
-.reader-selection-button:hover {
-  transform: translateY(-1px);
-  border-color: rgba(59, 130, 246, 0.55);
-}
-
-.reader-highlight-option {
-  position: relative;
-  color: rgba(30, 64, 175, 0.9);
-}
-
-.reader-highlight-option::after {
-  content: '';
-  position: absolute;
-  inset: 0.3rem;
-  border-radius: 9999px;
-  background: var(--highlight-swatch);
-  opacity: 0.75;
-  z-index: -1;
-}
-
-.reader-highlight-option.active {
-  border-color: rgba(59, 130, 246, 0.7);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
-}
-
-.dark .reader-highlight-option,
-.dark .reader-selection-button {
-  background: rgba(30, 41, 59, 0.9);
-  border-color: rgba(148, 163, 184, 0.35);
-  color: rgba(226, 232, 240, 0.9);
+  color: rgba(165, 180, 252, 0.85);
 }
 
 .post-content ol li {


### PR DESCRIPTION
## Summary
- redesign the interactive reading selection popover with a compact highlight toggle, color palette, and quick actions for dictionary, copy, share, and listen
- refresh the associated selection styling to match the new floating bubble design with snippet preview and dark theme support

## Testing
- npm run lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d369c458ec832da7e95da9ec3cbf8d