### PR TITLE
Fix quiz slug route matching

### DIFF
--- a/api/routes/quiz.route.js
+++ b/api/routes/quiz.route.js
@@ -21,11 +21,11 @@ router.post('/quizzes', verifyToken, createQuiz);
 // GET all quizzes (Public)
 router.get('/quizzes', getQuizzes);
 
-// GET a single quiz by ID (Public)
-router.get('/quizzes/:quizId', getSingleQuizById);
-
 // GET a single quiz by slug (Public)
 router.get('/quizzes/slug/:quizSlug', getSingleQuizBySlug);
+
+// GET a single quiz by ID (Public)
+router.get('/quizzes/:quizId([a-fA-F0-9]{24})', getSingleQuizById);
 
 // UPDATE a quiz (Admin-only)
 router.put('/quizzes/:quizId/:userId', verifyToken, updateQuiz);

--- a/api/routes/quiz.route.test.js
+++ b/api/routes/quiz.route.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import router from './quiz.route.js';
+import { getSingleQuizBySlug, getSingleQuizById } from '../controllers/quiz.controller.js';
+
+const getRouteOrderIndex = (handler) => {
+    const layers = router.stack.filter(layer => layer.route);
+    return layers.findIndex(layer =>
+        layer.route.stack.some(stackItem => stackItem.handle === handler)
+    );
+};
+
+test('slug route is registered before id route to avoid path collisions', () => {
+    const slugIndex = getRouteOrderIndex(getSingleQuizBySlug);
+    const idIndex = getRouteOrderIndex(getSingleQuizById);
+
+    assert.notEqual(slugIndex, -1, 'Slug route should be registered');
+    assert.notEqual(idIndex, -1, 'ID route should be registered');
+    assert.ok(
+        slugIndex < idIndex,
+        'Slug route must be registered before the more generic ID route'
+    );
+});


### PR DESCRIPTION
## Summary
- ensure the quiz slug endpoint is registered before the generic ID matcher and restrict the ID path to Mongo ObjectIds so slugs no longer resolve to the wrong handler
- add a regression test that verifies the slug route stays ahead of the ID route in the router stack

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3df9f108c8331a7bc90462808ed8c