### PR TITLE
Adjust recent articles card spacing

### DIFF
--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -357,7 +357,7 @@ export default function PostCard({ post }) {
     return (
         <motion.div
             layoutId={`post-card-${post.slug}`}
-            className='w-full border dark:border-slate-700 border-gray-200 rounded-xl sm:w-[420px] mx-auto shadow-md hover:shadow-xl transition-shadow duration-300 flex flex-col bg-white dark:bg-slate-800 overflow-hidden'
+            className='w-full h-full border dark:border-slate-700 border-gray-200 rounded-xl shadow-md hover:shadow-xl transition-shadow duration-300 flex flex-col bg-white dark:bg-slate-800 overflow-hidden'
             initial={{ opacity: 0, y: 50 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, amount: 0.1 }}

--- a/client/src/components/skeletons/PostCardSkeleton.jsx
+++ b/client/src/components/skeletons/PostCardSkeleton.jsx
@@ -1,6 +1,6 @@
 export default function PostCardSkeleton() {
     return (
-        <div className='w-full border dark:border-slate-700 border-gray-200 h-[460px] overflow-hidden rounded-xl sm:w-[380px] mx-auto shadow-lg relative animate-fade-in'>
+        <div className='w-full h-full border dark:border-slate-700 border-gray-200 h-[460px] overflow-hidden rounded-xl shadow-lg relative animate-fade-in'>
             {/* Media part - Mimics the slight shadow/lift of the actual image */}
             <div className='h-[220px] w-full bg-gray-200 dark:bg-slate-700 animate-pulse-slow rounded-t-xl overflow-hidden relative'>
                 {/* Subtle gradient overlay to mimic media depth */}


### PR DESCRIPTION
## Summary
- remove fixed card widths from the PostCard component so the home page "Recently Published Articles" grid can use the full column width
- align the PostCard skeleton styling with the production card so the loading state matches the new responsive spacing

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_b_68d402b5327c83318e1325d241649607