### PR TITLE
Make PostCard height auto

### DIFF
--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -398,7 +398,7 @@ export default function PostCard({ post }) {
     return (
         <motion.div
             layoutId={`post-card-${post.slug || post._id || 'unknown'}`}
-            className='w-full h-full border dark:border-slate-700 border-gray-200 rounded-xl shadow-md hover:shadow-xl transition-shadow duration-300 flex flex-col bg-white dark:bg-slate-800 overflow-hidden'
+            className='w-full border dark:border-slate-700 border-gray-200 rounded-xl shadow-md hover:shadow-xl transition-shadow duration-300 flex flex-col bg-white dark:bg-slate-800 overflow-hidden'
             initial={{ opacity: 0, y: 50 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, amount: 0.1 }}

--- a/client/src/components/skeletons/PostCardSkeleton.jsx
+++ b/client/src/components/skeletons/PostCardSkeleton.jsx
@@ -1,6 +1,6 @@
 export default function PostCardSkeleton() {
     return (
-        <div className='w-full h-full border dark:border-slate-700 border-gray-200 h-[460px] overflow-hidden rounded-xl shadow-lg relative animate-fade-in'>
+        <div className='w-full border dark:border-slate-700 border-gray-200 overflow-hidden rounded-xl shadow-lg relative animate-fade-in flex flex-col'>
             {/* Media part - Mimics the slight shadow/lift of the actual image */}
             <div className='h-[220px] w-full bg-gray-200 dark:bg-slate-700 animate-pulse-slow rounded-t-xl overflow-hidden relative'>
                 {/* Subtle gradient overlay to mimic media depth */}
@@ -23,7 +23,7 @@ export default function PostCardSkeleton() {
             </div>
 
             {/* Content part - Enhanced placeholders */}
-            <div className='p-4 flex flex-col gap-2 bg-white dark:bg-slate-800 flex-grow h-[240px]'>
+            <div className='p-4 flex flex-col gap-2 bg-white dark:bg-slate-800 flex-grow'>
                 {/* Category & Reading Time */}
                 <div className='flex justify-between items-center text-xs'>
                     <div className='h-5 w-20 bg-teal-100/50 dark:bg-teal-900/50 animate-pulse-slow rounded-full shadow-sm'></div> {/* Softer teal for category */}


### PR DESCRIPTION
## Summary
- remove the forced full-height styling on the PostCard container so cards size naturally with their content
- align the PostCard skeleton styling with the new auto-height layout by dropping the fixed height wrappers

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d40aa180488331b80db20ed8357107