### PR TITLE
Replace Flowbite switch with ToggleSwitch

### DIFF
--- a/client/src/pages/CreateProblem.jsx
+++ b/client/src/pages/CreateProblem.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Alert, Button, Label, Select, Switch, TextInput, Textarea } from 'flowbite-react';
+import { Alert, Button, Label, Select, TextInput, Textarea, ToggleSwitch } from 'flowbite-react';
 import { useMutation } from '@tanstack/react-query';
 import { FaPlus, FaTrash } from 'react-icons/fa';
 
@@ -141,17 +141,17 @@ export default function CreateProblem() {
                             <TextInput id="estimatedTime" type="number" min="0" value={formData.estimatedTime} onChange={handleInputChange} />
                         </div>
                         <div className="flex items-center gap-3 pt-6">
-                            <Switch
+                            <ToggleSwitch
                                 id="isPublished"
                                 checked={formData.isPublished}
-                                onChange={(event) =>
+                                label="Publish immediately"
+                                onChange={(value) =>
                                     setFormData((prev) => ({
                                         ...prev,
-                                        isPublished: event.target.checked,
+                                        isPublished: value,
                                     }))
                                 }
                             />
-                            <Label htmlFor="isPublished">Publish immediately</Label>
                         </div>
                     </div>
                     <div>

--- a/client/src/pages/UpdateProblem.jsx
+++ b/client/src/pages/UpdateProblem.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Alert, Button, Label, Select, Switch, TextInput, Textarea, Spinner } from 'flowbite-react';
+import { Alert, Button, Label, Select, TextInput, Textarea, Spinner, ToggleSwitch } from 'flowbite-react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { FaPlus, FaTrash } from 'react-icons/fa';
 
@@ -180,17 +180,17 @@ export default function UpdateProblem() {
                             <TextInput id="estimatedTime" type="number" min="0" value={formData.estimatedTime} onChange={handleInputChange} />
                         </div>
                         <div className="flex items-center gap-3 pt-6">
-                            <Switch
+                            <ToggleSwitch
                                 id="isPublished"
                                 checked={formData.isPublished}
-                                onChange={(event) =>
+                                label="Published"
+                                onChange={(value) =>
                                     setFormData((prev) => ({
                                         ...prev,
-                                        isPublished: event.target.checked,
+                                        isPublished: value,
                                     }))
                                 }
                             />
-                            <Label htmlFor="isPublished">Published</Label>
                         </div>
                     </div>
                     <div>


### PR DESCRIPTION
## Summary
- replace deprecated Switch import from Flowbite React with the supported ToggleSwitch component in the create and update problem forms
- wire the toggle switch to update the publication flag using the boolean value provided by the new component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d4a70d7d6083318c7d5d9da0db20c4