### PR TITLE
Enhance SingleProblemPage experience

### DIFF
--- a/client/src/pages/SingleProblemPage.jsx
+++ b/client/src/pages/SingleProblemPage.jsx
@@ -1,7 +1,15 @@
+import { useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Alert, Breadcrumb, Spinner } from 'flowbite-react';
-import { HiHome, HiArrowLeft } from 'react-icons/hi2';
+import {
+    HiHome,
+    HiArrowLeft,
+    HiOutlineSparkles,
+    HiOutlineClock,
+    HiOutlineAcademicCap,
+    HiOutlinePresentationChartLine,
+} from 'react-icons/hi2';
 
 import { getProblemBySlug } from '../services/problemService';
 import ProblemStatsBar from '../components/problems/ProblemStatsBar';
@@ -9,6 +17,7 @@ import ProblemResourceLinks from '../components/problems/ProblemResourceLinks';
 import ProblemMetaSummary from '../components/problems/ProblemMetaSummary';
 import ProblemWorkspace from '../components/problems/ProblemWorkspace';
 import CodeEditor from '../components/CodeEditor';
+import ProblemDifficultyBadge from '../components/problems/ProblemDifficultyBadge';
 
 export default function SingleProblemPage() {
     const { problemSlug } = useParams();
@@ -37,44 +46,156 @@ export default function SingleProblemPage() {
         );
     }
 
+    const topTopics = useMemo(() => data.topics?.slice(0, 3) ?? [], [data.topics]);
+    const highlightedTags = useMemo(() => data.tags?.slice(0, 4) ?? [], [data.tags]);
+
     return (
-        <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100 pb-20 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
-            <div className="border-b border-slate-200 bg-white/70 backdrop-blur dark:border-slate-800 dark:bg-slate-900/60">
-                <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
-                    <Breadcrumb aria-label="Problem breadcrumb" className="text-sm text-slate-500 dark:text-slate-400">
-                        <Breadcrumb.Item href="/" icon={HiHome}>
-                            Home
-                        </Breadcrumb.Item>
-                        <Breadcrumb.Item href="/problems">Problem Solving</Breadcrumb.Item>
-                        <Breadcrumb.Item>{data.title}</Breadcrumb.Item>
-                    </Breadcrumb>
-                    <div className="space-y-4">
-                        <div className="inline-flex items-center gap-3 rounded-full bg-cyan-100/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-200">
-                            Interview practice
-                        </div>
-                        <h1 className="text-4xl font-extrabold text-slate-900 dark:text-white">{data.title}</h1>
-                        <p className="max-w-3xl text-lg text-slate-600 dark:text-slate-300">{data.description}</p>
-                        <ProblemStatsBar stats={data.stats} successRate={data.successRate} estimatedTime={data.estimatedTime} />
-                    </div>
-                </div>
+        <div className="relative min-h-screen bg-slate-50 pb-24 dark:bg-slate-950">
+            <div className="absolute inset-x-0 top-0 -z-10 flex justify-center overflow-hidden">
+                <div className="pointer-events-none h-[420px] w-full max-w-5xl -translate-y-24 rounded-full bg-gradient-to-b from-cyan-200/60 via-transparent to-transparent blur-3xl dark:from-cyan-500/20" />
             </div>
 
-            <div className="mx-auto mt-10 max-w-6xl px-4 sm:px-6 lg:px-8">
-                <div className="grid gap-8 lg:grid-cols-[1.15fr,0.85fr]">
-                    <div className="space-y-8">
-                        <ProblemWorkspace problem={data} />
-                        <ProblemResourceLinks resources={data.resources} />
-                        <Link
-                            to="/problems"
-                            className="inline-flex items-center gap-2 text-sm font-semibold text-cyan-600 transition hover:text-cyan-500 dark:text-cyan-300"
-                        >
-                            <HiArrowLeft className="h-4 w-4" />
-                            Back to problem list
-                        </Link>
+            <header className="border-b border-slate-200/60 bg-white/80 shadow-sm backdrop-blur-lg dark:border-slate-800/60 dark:bg-slate-900/80">
+                <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8">
+                    <div className="flex flex-wrap items-center justify-between gap-4">
+                        <Breadcrumb aria-label="Problem breadcrumb" className="text-sm text-slate-500 dark:text-slate-400">
+                            <Breadcrumb.Item href="/" icon={HiHome}>
+                                Home
+                            </Breadcrumb.Item>
+                            <Breadcrumb.Item href="/problems">Problem Solving</Breadcrumb.Item>
+                            <Breadcrumb.Item>{data.title}</Breadcrumb.Item>
+                        </Breadcrumb>
+                        <div className="flex items-center gap-2 rounded-full bg-cyan-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-700 shadow-sm ring-1 ring-cyan-100 dark:bg-cyan-900/30 dark:text-cyan-200 dark:ring-cyan-800/40">
+                            <HiOutlineSparkles className="h-4 w-4" />
+                            Interview ready
+                        </div>
                     </div>
 
-                    <aside className="space-y-6">
-                        <section className="overflow-hidden rounded-3xl border border-slate-200 bg-white/80 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                    <div className="space-y-6">
+                        <div className="flex flex-wrap items-center gap-3">
+                            <ProblemDifficultyBadge difficulty={data.difficulty} />
+                            {data.companies?.length ? (
+                                <div className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-100 dark:bg-emerald-500/10 dark:text-emerald-200 dark:ring-emerald-500/40">
+                                    <HiOutlinePresentationChartLine className="h-4 w-4" />
+                                    Asked at {data.companies.slice(0, 2).join(', ')}
+                                    {data.companies.length > 2 ? ' +' + (data.companies.length - 2) : ''}
+                                </div>
+                            ) : null}
+                        </div>
+                        <h1 className="text-4xl font-black tracking-tight text-slate-900 dark:text-white sm:text-5xl">{data.title}</h1>
+                        <p className="max-w-3xl text-lg leading-relaxed text-slate-600 dark:text-slate-300">{data.description}</p>
+
+                        <div className="grid gap-4 rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-xl shadow-cyan-100/50 ring-1 ring-slate-100 dark:border-slate-800 dark:bg-slate-900/70 dark:shadow-none dark:ring-slate-800">
+                            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                                <div className="space-y-1">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Success rate</p>
+                                    <p className="text-2xl font-semibold text-slate-900 dark:text-white">{data.successRate ? `${data.successRate}%` : '—'}</p>
+                                </div>
+                                <div className="space-y-1">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Estimated effort</p>
+                                    <p className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+                                        <HiOutlineClock className="h-4 w-4 text-cyan-500" />
+                                        {data.estimatedTime ? `${data.estimatedTime} mins` : 'Plan your own pace'}
+                                    </p>
+                                </div>
+                                <div className="space-y-1">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Core topics</p>
+                                    <div className="flex flex-wrap gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+                                        {topTopics.length
+                                            ? topTopics.map((topic) => (
+                                                  <span key={topic} className="inline-flex items-center rounded-full bg-cyan-100/70 px-2.5 py-1 text-xs font-semibold text-cyan-800 dark:bg-cyan-500/10 dark:text-cyan-200">
+                                                      {topic}
+                                                  </span>
+                                              ))
+                                            : 'General problem solving'}
+                                    </div>
+                                </div>
+                                <div className="space-y-1">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Session goal</p>
+                                    <p className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+                                        <HiOutlineAcademicCap className="h-4 w-4 text-violet-500" />
+                                        Strengthen pattern recognition
+                                    </p>
+                                </div>
+                            </div>
+                            <ProblemStatsBar stats={data.stats} successRate={data.successRate} estimatedTime={data.estimatedTime} />
+                        </div>
+
+                        {highlightedTags.length ? (
+                            <div className="flex flex-wrap gap-2 text-sm text-slate-500 dark:text-slate-400">
+                                {highlightedTags.map((tag) => (
+                                    <span key={tag} className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600 ring-1 ring-slate-200 dark:bg-slate-800/70 dark:text-slate-200 dark:ring-slate-700">
+                                        #{tag}
+                                    </span>
+                                ))}
+                            </div>
+                        ) : null}
+
+                        <div className="flex flex-wrap gap-3">
+                            <a
+                                href="#interactive-editor"
+                                className="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-600 px-6 py-2 text-sm font-semibold text-white shadow-lg shadow-cyan-600/30 transition hover:bg-cyan-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+                            >
+                                Start coding now
+                            </a>
+                            <Link
+                                to="/problems"
+                                className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-6 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:text-cyan-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+                            >
+                                <HiArrowLeft className="h-4 w-4" />
+                                Back to catalogue
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+            </header>
+
+            <main className="mx-auto mt-12 max-w-6xl px-4 sm:px-6 lg:px-8">
+                <div className="grid gap-10 lg:grid-cols-[1.12fr,0.88fr] xl:gap-12">
+                    <div className="space-y-10">
+                        <section className="rounded-3xl border border-slate-200 bg-white/70 p-8 shadow-lg shadow-slate-200/60 ring-1 ring-slate-100 dark:border-slate-800 dark:bg-slate-900/70 dark:shadow-none dark:ring-slate-800">
+                            <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+                                <div className="space-y-3">
+                                    <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Learning focus</h2>
+                                    <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                                        Build momentum with a structured plan. Skim the statement, attempt the solution solo, and only then explore hints and editorial guidance.
+                                    </p>
+                                </div>
+                                <div className="flex items-start gap-4 rounded-2xl bg-cyan-50/60 p-4 text-sm text-cyan-800 ring-1 ring-cyan-100 dark:bg-cyan-900/30 dark:text-cyan-200 dark:ring-cyan-800/40">
+                                    <HiOutlineSparkles className="mt-0.5 h-5 w-5" />
+                                    <p>Time-box your attempt to stay interview-ready and track insights in the notebook of your choice.</p>
+                                </div>
+                            </div>
+
+                            <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                                <div className="rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-inner dark:border-slate-700 dark:bg-slate-900/70">
+                                    <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Prep steps</h3>
+                                    <ol className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                                        <li>1. Understand the narrative and constraints.</li>
+                                        <li>2. Identify patterns from similar challenges.</li>
+                                        <li>3. Outline brute-force and optimized strategies.</li>
+                                    </ol>
+                                </div>
+                                <div className="rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-inner dark:border-slate-700 dark:bg-slate-900/70">
+                                    <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Reflection prompts</h3>
+                                    <ol className="mt-3 space-y-2 text-sm text-slate-600 dark:text-slate-300">
+                                        <li>• What invariants or data structures unlock the problem?</li>
+                                        <li>• How does space-time complexity evolve across iterations?</li>
+                                        <li>• Can you communicate the reasoning succinctly?</li>
+                                    </ol>
+                                </div>
+                            </div>
+                        </section>
+
+                        <ProblemWorkspace problem={data} />
+                        <ProblemResourceLinks resources={data.resources} />
+                    </div>
+
+                    <aside className="space-y-8 lg:sticky lg:top-28">
+                        <section
+                            id="interactive-editor"
+                            className="overflow-hidden rounded-3xl border border-slate-200 bg-white/80 shadow-xl shadow-slate-200/80 dark:border-slate-700 dark:bg-slate-900/70 dark:shadow-none"
+                        >
                             <div className="space-y-1 border-b border-slate-200 px-6 py-5 dark:border-slate-700">
                                 <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Interactive editor</h2>
                                 <p className="text-sm text-slate-500 dark:text-slate-400">
@@ -88,7 +209,25 @@ export default function SingleProblemPage() {
 
                         <ProblemMetaSummary problem={data} />
 
-                        <div className="rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                        <section className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-200/80 ring-1 ring-slate-100 dark:border-slate-700 dark:bg-slate-900/70 dark:shadow-none dark:ring-slate-800">
+                            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">Practice sprint</h3>
+                            <ul className="mt-4 space-y-4 text-sm text-slate-600 dark:text-slate-300">
+                                <li>
+                                    <p className="font-semibold text-slate-900 dark:text-white">Focus block (20 mins)</p>
+                                    <p className="text-sm text-slate-500 dark:text-slate-400">Solve without hints and log any edge cases you identify.</p>
+                                </li>
+                                <li>
+                                    <p className="font-semibold text-slate-900 dark:text-white">Debrief (10 mins)</p>
+                                    <p className="text-sm text-slate-500 dark:text-slate-400">Review your solution quality versus the editorial walkthrough.</p>
+                                </li>
+                                <li>
+                                    <p className="font-semibold text-slate-900 dark:text-white">Upskill (5 mins)</p>
+                                    <p className="text-sm text-slate-500 dark:text-slate-400">Capture key learnings and share insights with your study circle.</p>
+                                </li>
+                            </ul>
+                        </section>
+
+                        <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-200/80 ring-1 ring-slate-100 dark:border-slate-700 dark:bg-slate-900/70 dark:shadow-none dark:ring-slate-800">
                             <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">Share your solution</h3>
                             <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
                                 Publish a write-up in the ScientistShield community forum and help fellow learners master this challenge.
@@ -102,7 +241,7 @@ export default function SingleProblemPage() {
                         </div>
                     </aside>
                 </div>
-            </div>
+            </main>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- redesign the single problem hero with rich metadata, gradients, and quick actions
- introduce a guided practice section and topic highlights to orient learners before the workspace
- refresh the sidebar with a sticky layout, enhanced editor card, and practice sprint guidance

## Testing
- npm run build --prefix client *(fails: @import must precede all other statements and missing SiJava icon export in existing code)*

------
https://chatgpt.com/codex/tasks/task_b_68d4ba90eef48331a0c573eab11913be