### PR TITLE
Fix SingleProblemPage hook order

### DIFF
--- a/client/src/pages/SingleProblemPage.jsx
+++ b/client/src/pages/SingleProblemPage.jsx
@@ -28,6 +28,9 @@ export default function SingleProblemPage() {
         enabled: Boolean(problemSlug),
     });
 
+    const topTopics = useMemo(() => (data?.topics ?? []).slice(0, 3), [data?.topics]);
+    const highlightedTags = useMemo(() => (data?.tags ?? []).slice(0, 4), [data?.tags]);
+
     if (isLoading) {
         return (
             <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
@@ -45,9 +48,6 @@ export default function SingleProblemPage() {
             </div>
         );
     }
-
-    const topTopics = useMemo(() => data.topics?.slice(0, 3) ?? [], [data.topics]);
-    const highlightedTags = useMemo(() => data.tags?.slice(0, 4) ?? [], [data.tags]);
 
     return (
         <div className="relative min-h-screen bg-slate-50 pb-24 dark:bg-slate-950">


### PR DESCRIPTION
## Summary
- ensure SingleProblemPage memoized topic and tag slices are computed before conditional returns so React hooks run consistently
- prevent the "Rendered more hooks than during the previous render" runtime crash when loading problem data

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d4bbb239fc8331abd41e44248d7dfd