### PR TITLE
Handle missing request bodies in JavaScript runner

### DIFF
--- a/api/controllers/javascript.controller.test.js
+++ b/api/controllers/javascript.controller.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runJavascriptCode } from './javascript.controller.js';
+
+const createResponseDouble = () => {
+    const response = {
+        statusCode: 0,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+    };
+    return response;
+};
+
+test('runJavascriptCode returns 400 when request body is missing', async () => {
+    let receivedError;
+    const req = {};
+    const res = createResponseDouble();
+
+    await runJavascriptCode(req, res, (err) => {
+        receivedError = err;
+    });
+
+    assert.ok(receivedError instanceof Error, 'expected an error to be forwarded to next');
+    assert.equal(receivedError.statusCode, 400);
+    assert.equal(receivedError.message, 'JavaScript code is required.');
+});
+
+test('runJavascriptCode returns 400 when code is not a string', async () => {
+    let receivedError;
+    const req = { body: { code: 12345 } };
+    const res = createResponseDouble();
+
+    await runJavascriptCode(req, res, (err) => {
+        receivedError = err;
+    });
+
+    assert.ok(receivedError instanceof Error, 'expected an error to be forwarded to next');
+    assert.equal(receivedError.statusCode, 400);
+    assert.equal(receivedError.message, 'JavaScript code is required.');
+});
+
+test('runJavascriptCode executes provided JavaScript and returns stdout', async () => {
+    const req = { body: { code: "console.log('Hello from tests!')" } };
+    const res = createResponseDouble();
+    let nextCalled = false;
+
+    await runJavascriptCode(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.equal(nextCalled, false, 'next should not be called for successful execution');
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, { output: 'Hello from tests!\n', error: false });
+});


### PR DESCRIPTION
## Summary
- guard the JavaScript execution endpoint against missing or non-string request bodies
- ensure child process output is always returned as UTF-8 strings
- add regression tests covering success and error flows for the JavaScript runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4ca513f288331847bcd4d9776b344