### PR TITLE
Prevent nodemon restarts from temp code execution files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+temp/
 
 # Editor directories and files
 .vscode/*

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["api"],
+  "ext": "js,mjs,cjs,json",
+  "ignore": ["temp/**/*", "client/dist/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a nodemon configuration so the dev server ignores temporary execution artifacts
- ignore the temp directory in git to avoid committing runtime files

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d543887fc08331b8d2ca38e4ab08aa