### PR TITLE
Add Java support to code editor

### DIFF
--- a/api/controllers/java.controller.js
+++ b/api/controllers/java.controller.js
@@ -1,0 +1,51 @@
+import { execFile } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import { v4 as uuidv4 } from 'uuid';
+import { errorHandler } from '../utils/error.js';
+
+const __dirname = path.resolve();
+const TEMP_DIR = path.join(__dirname, 'temp');
+
+const execFileAsync = promisify(execFile);
+
+export const runJavaCode = async (req, res, next) => {
+    const { code } = req.body ?? {};
+
+    if (!code || typeof code !== 'string') {
+        return next(errorHandler(400, 'Java code is required.'));
+    }
+
+    const uniqueId = uuidv4();
+    const workDir = path.join(TEMP_DIR, uniqueId);
+    const fileName = 'Main.java';
+    const className = 'Main';
+
+    try {
+        await fs.promises.mkdir(workDir, { recursive: true });
+        const filePath = path.join(workDir, fileName);
+        await fs.promises.writeFile(filePath, code);
+
+        await execFileAsync('javac', [fileName], {
+            cwd: workDir,
+            timeout: 7000,
+        });
+
+        const { stdout } = await execFileAsync('java', [className], {
+            cwd: workDir,
+            timeout: 7000,
+        });
+
+        res.status(200).json({ output: stdout, error: false });
+    } catch (err) {
+        const output = err?.stderr || err?.stdout || err?.message || String(err);
+        res.status(200).json({ output, error: true });
+    } finally {
+        try {
+            await fs.promises.rm(workDir, { recursive: true, force: true });
+        } catch (cleanupError) {
+            // Ignore cleanup errors
+        }
+    }
+};

--- a/api/controllers/javascript.controller.js
+++ b/api/controllers/javascript.controller.js
@@ -4,7 +4,7 @@ import { spawn } from 'child_process';
 import { errorHandler } from '../utils/error.js';
 
 export const runJavascriptCode = async (req, res, next) => {
-    const { code } = req.body;
+    const { code } = req.body ?? {};
 
     if (!code || typeof code !== 'string') {
         return next(errorHandler(400, 'JavaScript code is required.'));
@@ -16,25 +16,28 @@ export const runJavascriptCode = async (req, res, next) => {
     let stdout = '';
     let stderr = '';
 
-    child.stdout.on('data', (data) => {
-        stdout += data.toString();
-    });
+    return new Promise((resolve) => {
+        child.stdout.on('data', (data) => {
+            stdout += data.toString();
+        });
 
-    child.stderr.on('data', (data) => {
-        stderr += data.toString();
-    });
+        child.stderr.on('data', (data) => {
+            stderr += data.toString();
+        });
 
-    child.on('close', (code) => {
-        if (code !== 0 || stderr) {
-            // If the process exits with a non-zero code or there's an error message
-            return next(errorHandler(400, stderr || `Execution failed with exit code ${code}`));
-        }
-        // Success
-        res.status(200).json({ output: stdout });
-    });
+        child.on('close', (exitCode) => {
+            if (exitCode !== 0 || stderr) {
+                next(errorHandler(400, stderr || `Execution failed with exit code ${exitCode}`));
+                return resolve();
+            }
 
-    child.on('error', (err) => {
-        // This catches errors in spawning the process itself
-        return next(errorHandler(500, `Failed to start process: ${err.message}`));
+            res.status(200).json({ output: stdout, error: false });
+            resolve();
+        });
+
+        child.on('error', (err) => {
+            next(errorHandler(500, `Failed to start process: ${err.message}`));
+            resolve();
+        });
     });
 };

--- a/api/index.js
+++ b/api/index.js
@@ -12,6 +12,7 @@ import codeSnippetRoutes from './routes/codeSnippet.route.js';
 import cppRoutes from './routes/cpp.route.js';
 import pythonRoutes from './routes/python.route.js';
 import javascriptRoutes from './routes/javascript.route.js';
+import javaRoutes from './routes/java.route.js';
 import pageRoutes from './routes/page.route.js';
 import problemRoutes from './routes/problem.route.js';
 
@@ -79,6 +80,7 @@ app.use('/api', problemRoutes);
 app.use('/api/code', cppRoutes); // NEW: Use the new C++ route
 app.use('/api/code', pythonRoutes); // NEW: Use the new Python route
 app.use('/api/code', javascriptRoutes);
+app.use('/api/code', javaRoutes);
 app.use('/api', pageRoutes);
 
 app.use(express.static(path.join(__dirname, '/client/dist')));

--- a/api/routes/java.route.js
+++ b/api/routes/java.route.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { runJavaCode } from '../controllers/java.controller.js';
+
+const router = express.Router();
+
+router.post('/run-java', runJavaCode);
+
+export default router;

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import LanguageSelector from './LanguageSelector';
 import useCodeSnippet from '../hooks/useCodeSnippet';
 
-const supportedLanguages = ['javascript', 'cpp', 'python'];
+const supportedLanguages = ['javascript', 'cpp', 'python', 'java'];
 const storageLanguages = [...supportedLanguages, 'html', 'css'];
 
 const languageAliases = {
@@ -21,6 +21,7 @@ const languageAliases = {
     python: 'python',
     'c++': 'cpp',
     cpp: 'cpp',
+    java: 'java',
     html: 'javascript',
     css: 'javascript',
 };
@@ -32,6 +33,7 @@ const storageLanguageAliases = {
     python: 'python',
     'c++': 'cpp',
     cpp: 'cpp',
+    java: 'java',
     html: 'html',
     css: 'css',
 };
@@ -134,6 +136,12 @@ int main() {
     std::cout << std::endl;
     return 0;
 }`,
+    java: `public class Main {
+  public static void main(String[] args) {
+    System.out.println("Hello from Java!");
+  }
+}
+`,
     python: `def hello_world():
   message = "Hello, Python World!"
   print(message)
@@ -141,7 +149,7 @@ int main() {
 hello_world()`
 };
 
-const visualizerSupportedLanguages = new Set(['python', 'cpp', 'javascript']);
+const visualizerSupportedLanguages = new Set(['python', 'cpp', 'javascript', 'java']);
 
 export default function CodeEditor({ initialCode = {}, language = 'javascript', snippetId }) {
     const { theme } = useSelector((state) => state.theme);
@@ -164,6 +172,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
         javascript: normalizedInitialCode.javascript || defaultCodes.javascript,
         cpp: normalizedInitialCode.cpp || defaultCodes.cpp,
         python: normalizedInitialCode.python || defaultCodes.python,
+        java: normalizedInitialCode.java || defaultCodes.java,
     });
 
     const [selectedLanguage, setSelectedLanguage] = useState(normalizedInitialLanguage);
@@ -198,6 +207,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             javascript: '/api/code/run-js',
             cpp: '/api/code/run-cpp',
             python: '/api/code/run-python',
+            java: '/api/code/run-java',
         };
 
         const endpoint = endpointMap[selectedLanguage];
@@ -254,6 +264,9 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             if (snippet.python && snippet.python.trim()) {
                 return 'python';
             }
+            if (snippet.java && snippet.java.trim()) {
+                return 'java';
+            }
             return selectedLanguage;
         })();
 
@@ -264,6 +277,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             javascript: snippet.js || defaultCodes.javascript,
             cpp: snippet.cpp || prevCodes.cpp || defaultCodes.cpp,
             python: snippet.python || prevCodes.python || defaultCodes.python,
+            java: snippet.java || prevCodes.java || defaultCodes.java,
         }));
         setSelectedLanguage(supportedLanguages.includes(preferredLanguage) ? preferredLanguage : 'javascript');
         setHasAppliedSnippet(true);
@@ -276,6 +290,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             javascript: (snippet?.js ?? normalizedInitialCode.javascript) || defaultCodes.javascript,
             cpp: (snippet?.cpp ?? normalizedInitialCode.cpp) || defaultCodes.cpp,
             python: (snippet?.python ?? normalizedInitialCode.python) || defaultCodes.python,
+            java: (snippet?.java ?? normalizedInitialCode.java) || defaultCodes.java,
         });
         setConsoleOutput('');
         setRunError(null);

--- a/client/src/components/LanguageSelector.jsx
+++ b/client/src/components/LanguageSelector.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import Button from './ui/Button';
 
-const languages = ['javascript', 'cpp', 'python'];
+const languages = ['javascript', 'cpp', 'python', 'java'];
 
 export default function LanguageSelector({ selectedLanguage, setSelectedLanguage }) {
     return (

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -71,6 +71,7 @@ const categoryToLanguageMap = {
     'JavaScript': 'javascript',
     'Python': 'python',
     'C++': 'cpp',
+    'Java': 'java',
 };
 
 // New sub-component for rendering dynamic chapter content.

--- a/client/src/pages/TryItPage.jsx
+++ b/client/src/pages/TryItPage.jsx
@@ -13,7 +13,7 @@ export default function TryItPage() {
     // Default message when there's no initial code
     const defaultCodeMessage = `// Welcome to the live code editor!
 // JavaScript runs on a Node.js runtime.
-// You can also switch to C++ or Python.
+// You can also switch to C++, Python, or Java.
 console.log('Happy coding with Node.js!');
 `;
 
@@ -24,7 +24,7 @@ console.log('Happy coding with Node.js!');
             setEditorLanguage('javascript');
         } else {
             setEditorCode(code);
-            const allowedLanguages = ['javascript', 'cpp', 'python'];
+            const allowedLanguages = ['javascript', 'cpp', 'python', 'java'];
             setEditorLanguage(allowedLanguages.includes(language) ? language : 'javascript');
         }
     }, [code, language]);


### PR DESCRIPTION
## Summary
- add backend routing and controller to compile and run Java snippets in a temp workspace
- extend the Monaco-based code editor and language selector to handle Java snippets and defaults across the UI
- adjust tutorial category mapping and improve the JavaScript controller to await execution and satisfy existing tests

## Testing
- npm test
- npm run lint --prefix client *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d54ea74550833196c8397617921bdd