### PR TITLE
Handle missing javac gracefully

### DIFF
--- a/api/controllers/java.controller.js
+++ b/api/controllers/java.controller.js
@@ -10,42 +10,53 @@ const TEMP_DIR = path.join(__dirname, 'temp');
 
 const execFileAsync = promisify(execFile);
 
-export const runJavaCode = async (req, res, next) => {
-    const { code } = req.body ?? {};
+const runExecFile = (...args) => execFileAsync(...args);
 
-    if (!code || typeof code !== 'string') {
-        return next(errorHandler(400, 'Java code is required.'));
-    }
+export const createRunJavaCode = ({ execFile: exec = runExecFile } = {}) => {
+    return async (req, res, next) => {
+        const { code } = req.body ?? {};
 
-    const uniqueId = uuidv4();
-    const workDir = path.join(TEMP_DIR, uniqueId);
-    const fileName = 'Main.java';
-    const className = 'Main';
-
-    try {
-        await fs.promises.mkdir(workDir, { recursive: true });
-        const filePath = path.join(workDir, fileName);
-        await fs.promises.writeFile(filePath, code);
-
-        await execFileAsync('javac', [fileName], {
-            cwd: workDir,
-            timeout: 7000,
-        });
-
-        const { stdout } = await execFileAsync('java', [className], {
-            cwd: workDir,
-            timeout: 7000,
-        });
-
-        res.status(200).json({ output: stdout, error: false });
-    } catch (err) {
-        const output = err?.stderr || err?.stdout || err?.message || String(err);
-        res.status(200).json({ output, error: true });
-    } finally {
-        try {
-            await fs.promises.rm(workDir, { recursive: true, force: true });
-        } catch (cleanupError) {
-            // Ignore cleanup errors
+        if (!code || typeof code !== 'string') {
+            return next(errorHandler(400, 'Java code is required.'));
         }
-    }
+
+        const uniqueId = uuidv4();
+        const workDir = path.join(TEMP_DIR, uniqueId);
+        const fileName = 'Main.java';
+        const className = 'Main';
+
+        try {
+            await fs.promises.mkdir(workDir, { recursive: true });
+            const filePath = path.join(workDir, fileName);
+            await fs.promises.writeFile(filePath, code);
+
+            await exec('javac', [fileName], {
+                cwd: workDir,
+                timeout: 7000,
+            });
+
+            const { stdout } = await exec('java', [className], {
+                cwd: workDir,
+                timeout: 7000,
+            });
+
+            res.status(200).json({ output: stdout, error: false });
+        } catch (err) {
+            let output;
+            if (err?.code === 'ENOENT') {
+                output = 'Java runtime or compiler is not available. Please install a JDK to run Java code.';
+            } else {
+                output = err?.stderr || err?.stdout || err?.message || String(err);
+            }
+            res.status(200).json({ output, error: true });
+        } finally {
+            try {
+                await fs.promises.rm(workDir, { recursive: true, force: true });
+            } catch (cleanupError) {
+                // Ignore cleanup errors
+            }
+        }
+    };
 };
+
+export const runJavaCode = createRunJavaCode();

--- a/api/controllers/java.controller.test.js
+++ b/api/controllers/java.controller.test.js
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRunJavaCode } from './java.controller.js';
+
+const createResponseDouble = () => {
+    const response = {
+        statusCode: 0,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+    };
+    return response;
+};
+
+test('runJavaCode returns 400 when request body is missing', async () => {
+    let receivedError;
+    const req = {};
+    const res = createResponseDouble();
+    const runJavaCode = createRunJavaCode();
+
+    await runJavaCode(req, res, (err) => {
+        receivedError = err;
+    });
+
+    assert.ok(receivedError instanceof Error, 'expected an error to be forwarded to next');
+    assert.equal(receivedError.statusCode, 400);
+    assert.equal(receivedError.message, 'Java code is required.');
+});
+
+test('runJavaCode returns 400 when code is not a string', async () => {
+    let receivedError;
+    const req = { body: { code: 12345 } };
+    const res = createResponseDouble();
+    const runJavaCode = createRunJavaCode();
+
+    await runJavaCode(req, res, (err) => {
+        receivedError = err;
+    });
+
+    assert.ok(receivedError instanceof Error, 'expected an error to be forwarded to next');
+    assert.equal(receivedError.statusCode, 400);
+    assert.equal(receivedError.message, 'Java code is required.');
+});
+
+test('runJavaCode returns helpful message when javac is unavailable', async () => {
+    const execCalls = [];
+    const execStub = async (command) => {
+        execCalls.push(command);
+        const error = new Error('spawn javac ENOENT');
+        error.code = 'ENOENT';
+        throw error;
+    };
+
+    const runJavaCode = createRunJavaCode({ execFile: execStub });
+    const req = { body: { code: 'public class Main { public static void main(String[] args) {} }' } };
+    const res = createResponseDouble();
+
+    await runJavaCode(req, res, () => {});
+
+    assert.deepEqual(execCalls, ['javac']);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, {
+        output: 'Java runtime or compiler is not available. Please install a JDK to run Java code.',
+        error: true,
+    });
+});
+
+test('runJavaCode executes provided Java and returns stdout', async () => {
+    const execCalls = [];
+    const execStub = async (command) => {
+        execCalls.push(command);
+        if (command === 'javac') {
+            return { stdout: '' };
+        }
+        if (command === 'java') {
+            return { stdout: 'Hello from Java!\n' };
+        }
+        throw new Error(`Unexpected command: ${command}`);
+    };
+
+    const runJavaCode = createRunJavaCode({ execFile: execStub });
+    const req = {
+        body: {
+            code: [
+                'public class Main {',
+                '    public static void main(String[] args) {',
+                "        System.out.println(\"Hello from Java!\");",
+                '    }',
+                '}',
+            ].join('\n'),
+        },
+    };
+    const res = createResponseDouble();
+
+    await runJavaCode(req, res, () => {});
+
+    assert.deepEqual(execCalls, ['javac', 'java']);
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, { output: 'Hello from Java!\n', error: false });
+});


### PR DESCRIPTION
## Summary
- add dependency injection around Java execution to provide a clearer error when javac/java are unavailable
- return a user-friendly message advising to install the JDK when the runtime or compiler cannot be spawned
- introduce comprehensive tests for the Java controller covering validation, error handling, and successful execution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d55412847483318603246609912de7