### PR TITLE
Add C# support to interactive code editor

### DIFF
--- a/api/controllers/codeSnippet.controller.js
+++ b/api/controllers/codeSnippet.controller.js
@@ -8,8 +8,16 @@ export const createCodeSnippet = async (req, res, next) => {
     if (!req.user.isAdmin) {
         return next(errorHandler(403, 'You are not allowed to create a code snippet'));
     }
-    const { html = '', css = '', js = '' } = req.body;
-    const newSnippet = new CodeSnippet({ html, css, js });
+    const {
+        html = '',
+        css = '',
+        js = '',
+        cpp = '',
+        python = '',
+        java = '',
+        csharp = '',
+    } = req.body;
+    const newSnippet = new CodeSnippet({ html, css, js, cpp, python, java, csharp });
 
     try {
         const savedSnippet = await newSnippet.save();

--- a/api/controllers/csharp.controller.js
+++ b/api/controllers/csharp.controller.js
@@ -1,0 +1,125 @@
+// api/controllers/csharp.controller.js
+import { execFile } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import { v4 as uuidv4 } from 'uuid';
+import { errorHandler } from '../utils/error.js';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.resolve();
+const TEMP_DIR = path.join(__dirname, 'temp');
+
+const runnerCandidates = [
+    {
+        name: 'dotnet-script',
+        async detect() {
+            await execFileAsync('dotnet-script', ['--version']);
+            return {
+                command: 'dotnet-script',
+                buildArgs: (filePath) => [filePath],
+                extension: '.csx',
+            };
+        },
+    },
+    {
+        name: 'dotnet-script (via dotnet CLI)',
+        async detect() {
+            await execFileAsync('dotnet', ['script', '--version']);
+            return {
+                command: 'dotnet',
+                buildArgs: (filePath) => ['script', filePath],
+                extension: '.csx',
+            };
+        },
+    },
+    {
+        name: 'csi',
+        async detect() {
+            await execFileAsync('csi', ['-help']);
+            return {
+                command: 'csi',
+                buildArgs: (filePath) => [filePath],
+                extension: '.csx',
+            };
+        },
+    },
+    {
+        name: 'scriptcs',
+        async detect() {
+            await execFileAsync('scriptcs', ['-help']);
+            return {
+                command: 'scriptcs',
+                buildArgs: (filePath) => [filePath],
+                extension: '.csx',
+            };
+        },
+    },
+];
+
+let cachedRunner = null;
+
+const findCSharpRunner = async () => {
+    if (cachedRunner) {
+        return cachedRunner;
+    }
+
+    for (const candidate of runnerCandidates) {
+        try {
+            const runner = await candidate.detect();
+            cachedRunner = runner;
+            return runner;
+        } catch (error) {
+            if (error?.code !== 'ENOENT') {
+                console.warn(`C# runner detection failed for ${candidate.name}: ${error.message}`);
+            }
+        }
+    }
+
+    return null;
+};
+
+const missingRuntimeMessage =
+    'C# runtime is not available on the server. Install dotnet-script, dotnet script, or csi to enable C# execution.';
+
+export const runCSharpCode = async (req, res, next) => {
+    const { code } = req.body;
+
+    if (typeof code !== 'string' || !code.trim()) {
+        return next(errorHandler(400, 'C# code is required.'));
+    }
+
+    await fs.promises.mkdir(TEMP_DIR, { recursive: true });
+
+    const runner = await findCSharpRunner();
+    if (!runner) {
+        return res.status(200).json({ output: missingRuntimeMessage, error: true });
+    }
+
+    const uniqueId = uuidv4();
+    const filePath = path.join(TEMP_DIR, `${uniqueId}${runner.extension || '.csx'}`);
+
+    try {
+        await fs.promises.writeFile(filePath, code);
+
+        const { stdout } = await execFileAsync(runner.command, runner.buildArgs(filePath), {
+            timeout: 5000,
+        });
+
+        res.status(200).json({ output: stdout, error: false });
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            cachedRunner = null;
+            return res.status(200).json({ output: missingRuntimeMessage, error: true });
+        }
+
+        const output = error?.stderr || error?.stdout || error?.message || String(error);
+        res.status(200).json({ output, error: true });
+    } finally {
+        try {
+            await fs.promises.unlink(filePath);
+        } catch {
+            // Ignore cleanup errors
+        }
+    }
+};

--- a/api/index.js
+++ b/api/index.js
@@ -13,6 +13,7 @@ import cppRoutes from './routes/cpp.route.js';
 import pythonRoutes from './routes/python.route.js';
 import javascriptRoutes from './routes/javascript.route.js';
 import javaRoutes from './routes/java.route.js';
+import csharpRoutes from './routes/csharp.route.js';
 import pageRoutes from './routes/page.route.js';
 import problemRoutes from './routes/problem.route.js';
 
@@ -81,6 +82,7 @@ app.use('/api/code', cppRoutes); // NEW: Use the new C++ route
 app.use('/api/code', pythonRoutes); // NEW: Use the new Python route
 app.use('/api/code', javascriptRoutes);
 app.use('/api/code', javaRoutes);
+app.use('/api/code', csharpRoutes);
 app.use('/api', pageRoutes);
 
 app.use(express.static(path.join(__dirname, '/client/dist')));

--- a/api/models/CodeSnippet.model.js
+++ b/api/models/CodeSnippet.model.js
@@ -14,6 +14,22 @@ const CodeSnippetSchema = new mongoose.Schema(
             type: String,
             default: '',
         },
+        cpp: {
+            type: String,
+            default: '',
+        },
+        python: {
+            type: String,
+            default: '',
+        },
+        java: {
+            type: String,
+            default: '',
+        },
+        csharp: {
+            type: String,
+            default: '',
+        },
     },
     { timestamps: true }
 );

--- a/api/routes/csharp.route.js
+++ b/api/routes/csharp.route.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { runCSharpCode } from '../controllers/csharp.controller.js';
+
+const router = express.Router();
+
+router.post('/run-csharp', runCSharpCode);
+
+export default router;

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import LanguageSelector from './LanguageSelector';
 import useCodeSnippet from '../hooks/useCodeSnippet';
 
-const supportedLanguages = ['javascript', 'cpp', 'python', 'java'];
+const supportedLanguages = ['javascript', 'cpp', 'python', 'java', 'csharp'];
 const storageLanguages = [...supportedLanguages, 'html', 'css'];
 
 const languageAliases = {
@@ -22,6 +22,9 @@ const languageAliases = {
     'c++': 'cpp',
     cpp: 'cpp',
     java: 'java',
+    csharp: 'csharp',
+    'c#': 'csharp',
+    cs: 'csharp',
     html: 'javascript',
     css: 'javascript',
 };
@@ -34,6 +37,9 @@ const storageLanguageAliases = {
     'c++': 'cpp',
     cpp: 'cpp',
     java: 'java',
+    csharp: 'csharp',
+    'c#': 'csharp',
+    cs: 'csharp',
     html: 'html',
     css: 'css',
 };
@@ -146,7 +152,19 @@ int main() {
   message = "Hello, Python World!"
   print(message)
 
-hello_world()`
+hello_world()`,
+    csharp: `using System;
+
+namespace ScientistShield
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello from C#!");
+        }
+    }
+}`,
 };
 
 const visualizerSupportedLanguages = new Set(['python', 'cpp', 'javascript', 'java']);
@@ -173,6 +191,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
         cpp: normalizedInitialCode.cpp || defaultCodes.cpp,
         python: normalizedInitialCode.python || defaultCodes.python,
         java: normalizedInitialCode.java || defaultCodes.java,
+        csharp: normalizedInitialCode.csharp || defaultCodes.csharp,
     });
 
     const [selectedLanguage, setSelectedLanguage] = useState(normalizedInitialLanguage);
@@ -208,6 +227,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             cpp: '/api/code/run-cpp',
             python: '/api/code/run-python',
             java: '/api/code/run-java',
+            csharp: '/api/code/run-csharp',
         };
 
         const endpoint = endpointMap[selectedLanguage];
@@ -267,6 +287,9 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             if (snippet.java && snippet.java.trim()) {
                 return 'java';
             }
+            if (snippet.csharp && snippet.csharp.trim()) {
+                return 'csharp';
+            }
             return selectedLanguage;
         })();
 
@@ -278,6 +301,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             cpp: snippet.cpp || prevCodes.cpp || defaultCodes.cpp,
             python: snippet.python || prevCodes.python || defaultCodes.python,
             java: snippet.java || prevCodes.java || defaultCodes.java,
+            csharp: snippet.csharp || prevCodes.csharp || defaultCodes.csharp,
         }));
         setSelectedLanguage(supportedLanguages.includes(preferredLanguage) ? preferredLanguage : 'javascript');
         setHasAppliedSnippet(true);
@@ -291,6 +315,7 @@ export default function CodeEditor({ initialCode = {}, language = 'javascript', 
             cpp: (snippet?.cpp ?? normalizedInitialCode.cpp) || defaultCodes.cpp,
             python: (snippet?.python ?? normalizedInitialCode.python) || defaultCodes.python,
             java: (snippet?.java ?? normalizedInitialCode.java) || defaultCodes.java,
+            csharp: (snippet?.csharp ?? normalizedInitialCode.csharp) || defaultCodes.csharp,
         });
         setConsoleOutput('');
         setRunError(null);

--- a/client/src/components/LanguageSelector.jsx
+++ b/client/src/components/LanguageSelector.jsx
@@ -3,7 +3,10 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import Button from './ui/Button';
 
-const languages = ['javascript', 'cpp', 'python', 'java'];
+const languages = ['javascript', 'cpp', 'python', 'java', 'csharp'];
+const languageLabels = {
+    csharp: 'C#',
+};
 
 export default function LanguageSelector({ selectedLanguage, setSelectedLanguage }) {
     return (
@@ -24,7 +27,7 @@ export default function LanguageSelector({ selectedLanguage, setSelectedLanguage
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}
                 >
-                    {lang.toUpperCase()}
+                    {languageLabels[lang] || lang.toUpperCase()}
                 </Button>
             ))}
         </motion.div>

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -72,6 +72,8 @@ const categoryToLanguageMap = {
     'Python': 'python',
     'C++': 'cpp',
     'Java': 'java',
+    'C#': 'csharp',
+    'CSharp': 'csharp',
 };
 
 // New sub-component for rendering dynamic chapter content.

--- a/client/src/pages/TryItPage.jsx
+++ b/client/src/pages/TryItPage.jsx
@@ -13,7 +13,7 @@ export default function TryItPage() {
     // Default message when there's no initial code
     const defaultCodeMessage = `// Welcome to the live code editor!
 // JavaScript runs on a Node.js runtime.
-// You can also switch to C++, Python, or Java.
+// You can also switch to C++, Python, Java, or C#.
 console.log('Happy coding with Node.js!');
 `;
 
@@ -24,7 +24,7 @@ console.log('Happy coding with Node.js!');
             setEditorLanguage('javascript');
         } else {
             setEditorCode(code);
-            const allowedLanguages = ['javascript', 'cpp', 'python', 'java'];
+            const allowedLanguages = ['javascript', 'cpp', 'python', 'java', 'csharp'];
             setEditorLanguage(allowedLanguages.includes(language) ? language : 'javascript');
         }
     }, [code, language]);


### PR DESCRIPTION
## Summary
- extend the web code editor to recognize C# with presets, aliases, and storage updates
- expose a new /api/code/run-csharp endpoint backed by a controller that attempts to execute scripts via available C# tooling
- allow code snippets to persist C# content alongside existing language fields

## Testing
- `npm test`
- `npm run lint` *(fails: existing lint errors across unrelated components)*

------
https://chatgpt.com/codex/tasks/task_b_68d5599e5a988331b1ab6e01a8572bbc