### PR TITLE
Clarify C# runtime installation options

### DIFF
--- a/api/controllers/csharp.controller.js
+++ b/api/controllers/csharp.controller.js
@@ -80,7 +80,7 @@ const findCSharpRunner = async () => {
 };
 
 const missingRuntimeMessage =
-    'C# runtime is not available on the server. Install dotnet-script, dotnet script, or csi to enable C# execution.';
+    'C# runtime is not available on the server. Install dotnet-script, dotnet script, csi, or scriptcs to enable C# execution.';
 
 export const runCSharpCode = async (req, res, next) => {
     const { code } = req.body;


### PR DESCRIPTION
## Summary
- update the missing runtime guidance to include scriptcs as a supported C# runner option

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5f856a9a883319ced7955b299eb66