### PR TITLE
Update .NET target framework for C# runner

### DIFF
--- a/api/controllers/csharp.controller.js
+++ b/api/controllers/csharp.controller.js
@@ -14,7 +14,7 @@ const projectFileTemplate = `<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- update the generated C# project template to target .NET 8.0
- ensure temporary dotnet builds avoid using unsupported net7.0 target framework

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5fb8b546c83318e5f87ff51954d9b