### PR TITLE
Hash updated user passwords before saving

### DIFF
--- a/api/services/user.service.js
+++ b/api/services/user.service.js
@@ -1,3 +1,4 @@
+import bcryptjs from 'bcryptjs';
 import User from '../models/user.model.js';
 
 /**
@@ -36,7 +37,7 @@ export const updateUserById = async (userId, updates) => {
     userToUpdate.email = updates.email;
   }
   if (updates.password) {
-    userToUpdate.password = updates.password;
+    userToUpdate.password = await bcryptjs.hash(updates.password, 10);
   }
   if (updates.profilePicture) {
     userToUpdate.profilePicture = updates.profilePicture;


### PR DESCRIPTION
## Summary
- hash updated user passwords in the user service to keep credentials encrypted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d72f98c7f883328172f5e358bdc70d