### PR TITLE
Refine sidebar styling for a polished look

### DIFF
--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,7 +1,7 @@
 import { NavLink, Link, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { motion, AnimatePresence, useMotionValue } from 'framer-motion';
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import {
     FaBook,
     FaChevronDown,
@@ -26,19 +26,20 @@ import { Avatar, Tooltip, Button } from 'flowbite-react';
 const SectionHeader = ({ label, isCollapsed }) => (
     <AnimatePresence>
         {!isCollapsed && (
-            <motion.h3
+            <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1, transition: { delay: 0.2 } }}
                 exit={{ opacity: 0 }}
-                className="px-3 mt-6 mb-2 text-xs font-medium tracking-wider uppercase text-neutral-500 dark:text-neutral-400 flex justify-between items-center"
+                className="px-3 mt-6 mb-3 text-[0.65rem] font-semibold tracking-[0.35em] uppercase text-neutral-500 dark:text-neutral-400 flex items-center"
             >
-                {label}
+                <span>{label}</span>
+                <div className="ml-3 hidden h-px flex-1 rounded-full bg-gradient-to-r from-transparent via-neutral-500/30 to-transparent lg:block" />
                 <Tooltip content={`Add New ${label}`} placement="right">
-                    <button className="text-neutral-500 hover:text-white transition-colors">
+                    <button className="ml-3 flex h-6 w-6 items-center justify-center rounded-full border border-neutral-500/40 text-neutral-500 transition-colors hover:border-white/70 hover:text-white">
                         <FaPlus size={10} />
                     </button>
                 </Tooltip>
-            </motion.h3>
+            </motion.div>
         )}
     </AnimatePresence>
 );
@@ -48,14 +49,12 @@ const NavItem = ({ to, icon: Icon, label, isCollapsed }) => (
         <NavLink to={to}>
             {({ isActive }) => (
                 <motion.div
-                    whileHover={{ x: 5, backgroundColor: 'rgba(100, 116, 139, 0.1)' }}
-                    transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-                    className={`
-                        flex items-center gap-3 w-full px-3 py-2.5 rounded-lg font-medium text-left transition-colors duration-200 relative
+                    whileHover={isCollapsed ? { scale: 1.05 } : { x: 6 }}
+                    transition={{ type: 'spring', stiffness: 320, damping: 22 }}
+                    className={`relative flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors duration-200
                         ${isActive
-                        ? 'bg-neutral-700/60 text-white'
-                        : 'text-neutral-400 group-hover:text-white'
-                    }
+                        ? 'text-white'
+                        : 'text-neutral-400 hover:text-white'}
                         ${isCollapsed ? 'justify-center px-0' : ''}
                     `}
                 >
@@ -63,7 +62,7 @@ const NavItem = ({ to, icon: Icon, label, isCollapsed }) => (
                         {isActive && (
                             <motion.div
                                 layoutId="active-nav-item-indicator"
-                                className="absolute left-0 top-2 bottom-2 w-1 bg-accent-teal rounded-r-full"
+                                className="absolute inset-0 rounded-xl border border-sky-300/30 bg-gradient-to-r from-sky-500/20 via-transparent to-transparent shadow-[0_12px_32px_-16px_rgba(15,23,42,0.65)]"
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
                                 exit={{ opacity: 0 }}
@@ -72,18 +71,18 @@ const NavItem = ({ to, icon: Icon, label, isCollapsed }) => (
                     </AnimatePresence>
 
                     {Icon && (
-                        <motion.div whileHover={{ scale: 1.1 }}>
-                            <Icon className="h-5 w-5 flex-shrink-0" />
+                        <motion.div className="relative z-10 flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/10 text-white shadow-inner dark:border-slate-600/40 dark:bg-slate-900/40" whileHover={{ scale: 1.08 }}>
+                            <Icon className="h-4 w-4" />
                         </motion.div>
                     )}
 
                     <AnimatePresence>
                         {!isCollapsed && (
                             <motion.span
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1, transition: { delay: 0.1 } }}
-                                exit={{ opacity: 0 }}
-                                className="whitespace-nowrap"
+                                initial={{ opacity: 0, x: -6 }}
+                                animate={{ opacity: 1, x: 0, transition: { delay: 0.1 } }}
+                                exit={{ opacity: 0, x: -6 }}
+                                className="relative z-10 whitespace-nowrap"
                             >
                                 {label}
                             </motion.span>
@@ -115,27 +114,27 @@ const CollapsibleNavItem = ({ icon: Icon, label, isCollapsed, children }) => {
         >
             <Tooltip content={label} placement="right" animation="duration-300" disabled={!isCollapsed}>
                 <motion.button
-                    whileHover={!isCollapsed ? { x: 5, backgroundColor: 'rgba(100, 116, 139, 0.1)' } : {}}
-                    transition={{ type: 'spring', stiffness: 400, damping: 15 }}
+                    whileHover={!isCollapsed ? { x: 6 } : { scale: 1.05 }}
+                    transition={{ type: 'spring', stiffness: 320, damping: 22 }}
                     onClick={() => !isCollapsed && setIsInlineOpen(!isInlineOpen)}
-                    className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg font-medium text-left transition-colors duration-200 text-base relative ${
-                        (isActive || isInlineOpen && !isCollapsed) ? 'bg-neutral-700/30 text-white' : 'text-neutral-400 hover:text-white'
+                    className={`relative flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-semibold transition-colors duration-200 ${
+                        (isActive || (isInlineOpen && !isCollapsed)) ? 'text-white' : 'text-neutral-400 hover:text-white'
                     } ${isCollapsed ? 'justify-center px-0' : ''}`}
                 >
                     <AnimatePresence>
-                        {isActive && (
+                        {(isActive || (isInlineOpen && !isCollapsed)) && (
                             <motion.div
                                 layoutId="active-nav-item-indicator"
-                                className="absolute left-0 top-2 bottom-2 w-1 bg-accent-teal rounded-r-full"
+                                className="absolute inset-0 rounded-xl border border-sky-300/30 bg-gradient-to-r from-sky-500/15 via-transparent to-transparent shadow-[0_12px_32px_-16px_rgba(15,23,42,0.65)]"
                             />
                         )}
                     </AnimatePresence>
-                    <motion.div whileHover={{ scale: 1.1 }}>
-                        <Icon className="h-5 w-5 flex-shrink-0" />
+                    <motion.div className="relative z-10 flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/10 text-white shadow-inner dark:border-slate-600/40 dark:bg-slate-900/40" whileHover={{ scale: 1.08 }}>
+                        <Icon className="h-4 w-4" />
                     </motion.div>
-                    {!isCollapsed && <span className="flex-1 whitespace-nowrap">{label}</span>}
+                    {!isCollapsed && <span className="relative z-10 flex-1 whitespace-nowrap">{label}</span>}
                     {!isCollapsed && (
-                        <motion.div animate={{ rotate: isInlineOpen ? 0 : -90 }} transition={{ duration: 0.2 }}>
+                        <motion.div className="relative z-10" animate={{ rotate: isInlineOpen ? 0 : -90 }} transition={{ duration: 0.2 }}>
                             <FaChevronDown size={12} />
                         </motion.div>
                     )}
@@ -149,9 +148,9 @@ const CollapsibleNavItem = ({ icon: Icon, label, isCollapsed, children }) => {
                         animate={{ height: 'auto', opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}
                         transition={{ duration: 0.3, ease: 'easeInOut' }}
-                        className="overflow-hidden ml-4 pl-[1.1rem] border-l border-neutral-700"
+                        className="ml-4 overflow-hidden rounded-xl border border-white/5 bg-white/5 pl-[1.1rem] shadow-inner dark:border-slate-700/40 dark:bg-slate-900/30"
                     >
-                        <div className="pt-1 flex flex-col gap-1">{children}</div>
+                        <div className="flex flex-col gap-1 py-2">{children}</div>
                     </motion.div>
                 )}
             </AnimatePresence>
@@ -163,9 +162,9 @@ const CollapsibleNavItem = ({ icon: Icon, label, isCollapsed, children }) => {
                         animate={{ opacity: 1, scale: 1, x: 0 }}
                         exit={{ opacity: 0, scale: 0.95, x: -10 }}
                         transition={{ duration: 0.2 }}
-                        className="absolute left-full top-0 ml-2 bg-neutral-800/90 backdrop-blur-sm p-2 rounded-lg shadow-xl w-40 border border-neutral-700 z-50"
+                        className="absolute left-full top-0 z-50 ml-3 w-48 rounded-xl border border-white/10 bg-slate-900/90 p-3 shadow-2xl backdrop-blur"
                     >
-                        {children}
+                        <div className="flex flex-col gap-1 text-sm text-neutral-300">{children}</div>
                     </motion.div>
                 )}
             </AnimatePresence>
@@ -176,17 +175,20 @@ const CollapsibleNavItem = ({ icon: Icon, label, isCollapsed, children }) => {
 const MessageItem = ({ name, avatar, isCollapsed }) => (
     <Link to="#">
         <motion.div
-            whileHover={!isCollapsed ? { x: 5, backgroundColor: 'rgba(100, 116, 139, 0.1)' } : {}}
-            transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-            className="flex items-center gap-3 px-3 py-2 rounded-lg text-neutral-400 hover:text-white transition-colors">
-            <Avatar img={avatar} rounded size="xs" />
+            whileHover={!isCollapsed ? { x: 6 } : { scale: 1.04 }}
+            transition={{ type: 'spring', stiffness: 320, damping: 22 }}
+            className="group flex items-center gap-3 rounded-xl px-3 py-2 text-sm text-neutral-400 transition-colors hover:text-white"
+        >
+            <div className="relative z-10 flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/10 text-white shadow-inner dark:border-slate-600/50 dark:bg-slate-900/50">
+                <Avatar img={avatar} rounded size="xs" />
+            </div>
             <AnimatePresence>
                 {!isCollapsed && (
                     <motion.span
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        className="whitespace-nowrap text-sm"
+                        initial={{ opacity: 0, x: -6 }}
+                        animate={{ opacity: 1, x: 0 }}
+                        exit={{ opacity: 0, x: -6 }}
+                        className="relative z-10 whitespace-nowrap"
                     >
                         {name}
                     </motion.span>
@@ -234,14 +236,19 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
             <NavLink to={to}>
                 {({ isActive }) => (
                     <motion.div
-                        whileHover={{ x: 5, backgroundColor: 'rgba(100, 116, 139, 0.1)' }}
-                        transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-                        className={`flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors duration-200 relative ${
-                            isActive ? 'bg-neutral-700/50 text-white' : 'text-neutral-400 hover:text-white'
+                        whileHover={{ x: 6 }}
+                        transition={{ type: 'spring', stiffness: 320, damping: 22 }}
+                        className={`relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors duration-200 ${
+                            isActive ? 'text-white' : 'text-neutral-400 hover:text-white'
                         }`}
                     >
-                        {isActive && <motion.div layoutId="active-nav-item-indicator" className="absolute left-0 top-1 bottom-1 w-0.5 bg-accent-teal rounded-r-full" />}
-                        {!isCollapsed && <span>{label}</span>}
+                        {isActive && (
+                            <motion.div
+                                layoutId="active-nav-item-indicator"
+                                className="absolute inset-0 rounded-lg border border-sky-300/20 bg-white/5 shadow-[0_10px_25px_-18px_rgba(15,23,42,0.7)] dark:bg-slate-900/30"
+                            />
+                        )}
+                        {!isCollapsed && <span className="relative z-10">{label}</span>}
                     </motion.div>
                 )}
             </NavLink>
@@ -251,54 +258,61 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
 
     return (
         <motion.aside
-            animate={{ width: isCollapsed ? '5rem' : '16rem' }}
+            animate={{ width: isCollapsed ? '5rem' : '17.5rem' }}
             transition={{ duration: 0.3, ease: [0.42, 0, 0.58, 1] }}
-            className="sidebar hidden md:flex flex-col fixed top-0 left-0 z-40 h-[calc(100vh-2rem)] my-4 ml-4 rounded-2xl border backdrop-blur-lg bg-white/60 dark:bg-slate-900/60 shadow-lg"
+            className="sidebar relative hidden md:flex flex-col fixed top-0 left-0 z-40 h-[calc(100vh-2rem)] my-4 ml-4 overflow-hidden rounded-3xl backdrop-blur-xl"
             onMouseMove={handleMouseMove}
         >
+            <div className="pointer-events-none absolute inset-0 z-0">
+                <div className="absolute inset-0 bg-gradient-to-b from-white/25 via-transparent to-transparent dark:from-slate-900/25" />
+                <div className="absolute left-14 top-12 h-36 w-36 rounded-full bg-sky-400/25 blur-3xl opacity-70 dark:bg-sky-400/20" />
+                <div className="absolute right-[-35%] bottom-[-20%] h-64 w-64 rounded-full bg-indigo-500/20 blur-[120px] opacity-60" />
+            </div>
             <motion.div
                 className="absolute inset-0 z-0 pointer-events-none"
                 style={{
-                    background: `radial-gradient(circle at ${mouseX}px ${mouseY}px, rgba(148, 163, 184, 0.05), transparent 40%)`
+                    background: `radial-gradient(circle at ${mouseX}px ${mouseY}px, rgba(148, 163, 184, 0.08), transparent 45%)`
                 }}
             />
-            <div className="relative z-10">
-                <div className={`flex items-center p-4 border-b ${isCollapsed ? 'justify-center' : 'justify-between'}`} style={{ borderColor: 'var(--color-sidebar-border)' }}>
+            <div className="relative z-10 flex h-full flex-col">
+                <div className={`flex items-start ${isCollapsed ? 'justify-center px-3 py-5' : 'justify-between px-5 py-6'} border-b border-white/10 dark:border-slate-700/60`}>
                     <AnimatePresence>
                         {!isCollapsed && (
-                            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1, transition: { delay: 0.2 } }} exit={{ opacity: 0 }}>
-                                <Link to="/" className="text-xl font-bold">ScientistShield</Link>
+                            <motion.div initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0, transition: { delay: 0.15 } }} exit={{ opacity: 0, y: -8 }}>
+                                <Link to="/" className="block">
+                                    <span className="block text-lg font-semibold text-white">Scientist<span className="text-sky-300">Shield</span></span>
+                                    <span className="mt-1 block text-[0.65rem] font-medium uppercase tracking-[0.4em] text-sky-200/70">Knowledge Suite</span>
+                                </Link>
                             </motion.div>
                         )}
                     </AnimatePresence>
                     <Tooltip content={isPinned ? "Unpin Sidebar" : "Pin Sidebar"} placement="right" animation="duration-300">
                         <motion.button
-                            whileHover={{ scale: 1.1, rotate: 15 }}
-                            whileTap={{ scale: 0.9 }}
+                            whileHover={{ scale: 1.08, rotate: 10 }}
+                            whileTap={{ scale: 0.92 }}
                             onClick={() => setIsPinned(!isPinned)}
-                            className="p-2 rounded-full hover:bg-neutral-700 transition-colors"
+                            className="rounded-full border border-white/10 p-2.5 text-neutral-400 transition-colors hover:border-white/40 hover:text-white"
                         >
                             <motion.div animate={{ rotate: isPinned ? 0 : 45 }}>
-                                <FaThumbtack className={isPinned ? 'text-white' : 'text-neutral-500'} />
+                                <FaThumbtack className={isPinned ? 'text-sky-300' : 'text-inherit'} />
                             </motion.div>
                         </motion.button>
                     </Tooltip>
                 </div>
 
                 <motion.div
-                    whileHover={{ backgroundColor: 'rgba(100, 116, 139, 0.1)' }}
-                    className={`p-4 border-b`}
-                    style={{ borderColor: 'var(--color-sidebar-border)' }}
+                    whileHover={!isCollapsed ? { backgroundColor: 'rgba(255,255,255,0.06)' } : {}}
+                    className={`border-b border-white/10 px-4 py-4 transition-colors dark:border-slate-700/60 ${isCollapsed ? 'flex justify-center' : ''}`}
                 >
                     {currentUser ? (
-                        <Link to="/dashboard?tab=profile">
-                            <div className={`flex items-center gap-3 ${isCollapsed ? 'justify-center' : ''}`}>
+                        <Link to="/dashboard?tab=profile" className="group block w-full">
+                            <div className={`flex items-center gap-3 rounded-2xl border border-white/10 bg-white/10 px-4 py-3 transition-colors group-hover:border-white/30 group-hover:bg-white/15 dark:border-slate-700/50 dark:bg-slate-900/40 ${isCollapsed ? 'justify-center' : ''}`}>
                                 <Avatar img={currentUser.profilePicture} rounded size="md" />
                                 <AnimatePresence>
                                     {!isCollapsed && (
-                                        <motion.div initial={{ opacity: 0, width: 0 }} animate={{ opacity: 1, width: 'auto', transition: { delay: 0.2 } }} exit={{ opacity: 0, width: 0 }} className="text-sm overflow-hidden">
+                                        <motion.div initial={{ opacity: 0, x: -10 }} animate={{ opacity: 1, x: 0, transition: { delay: 0.15 } }} exit={{ opacity: 0, x: -10 }} className="overflow-hidden text-sm">
                                             <p className="font-semibold text-white truncate">{currentUser.username}</p>
-                                            <p className="text-neutral-400 text-xs">Account Designer</p>
+                                            <p className="text-xs text-neutral-300/80">View profile & settings</p>
                                         </motion.div>
                                     )}
                                 </AnimatePresence>
@@ -308,65 +322,72 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
                         <NavItem to="/sign-in" icon={FaSignInAlt} label="Sign In" isCollapsed={isCollapsed} />
                     )}
                 </motion.div>
-            </div>
 
-            <nav className="flex-1 p-2 space-y-1 overflow-y-auto">
-                <SectionHeader label="Main" isCollapsed={isCollapsed} />
-                {currentUser?.isAdmin && (
-                    <>
-                        <NavItem
-                            to="/admin"
-                            icon={FaShieldAlt}
-                            label="Admin Panel"
-                            isCollapsed={isCollapsed}
-                        />
-                        <CollapsibleNavItem icon={FaTachometerAlt} label="Dashboard" isCollapsed={isCollapsed}>
-                            <SubItem to="/dashboard?tab=dash" label="Overview" />
-                            <SubItem to="/dashboard?tab=posts" label="Posts" />
-                            <SubItem to="/dashboard?tab=tutorials" label="Tutorials" />
-                            <SubItem to="/dashboard?tab=quizzes" label="Quizzes" />
-                            <SubItem to="/dashboard?tab=content" label="Content" />
-                            <SubItem to="/dashboard?tab=comments" label="Comments" />
-                            <SubItem to="/dashboard?tab=users" label="Users" />
-                        </CollapsibleNavItem>
-                    </>
-                )}
+                <nav className={`flex-1 overflow-y-auto ${isCollapsed ? 'space-y-4 px-2 py-4' : 'space-y-6 px-5 py-6'}`}>
+                    <div className={`${isCollapsed ? 'space-y-1' : 'space-y-2 rounded-2xl border border-white/10 bg-white/10 p-3 shadow-inner dark:border-slate-700/40 dark:bg-slate-900/35'}`}>
+                        <SectionHeader label="Main" isCollapsed={isCollapsed} />
+                        {currentUser?.isAdmin && (
+                            <>
+                                <NavItem
+                                    to="/admin"
+                                    icon={FaShieldAlt}
+                                    label="Admin Panel"
+                                    isCollapsed={isCollapsed}
+                                />
+                                <CollapsibleNavItem icon={FaTachometerAlt} label="Dashboard" isCollapsed={isCollapsed}>
+                                    <SubItem to="/dashboard?tab=dash" label="Overview" />
+                                    <SubItem to="/dashboard?tab=posts" label="Posts" />
+                                    <SubItem to="/dashboard?tab=tutorials" label="Tutorials" />
+                                    <SubItem to="/dashboard?tab=quizzes" label="Quizzes" />
+                                    <SubItem to="/dashboard?tab=content" label="Content" />
+                                    <SubItem to="/dashboard?tab=comments" label="Comments" />
+                                    <SubItem to="/dashboard?tab=users" label="Users" />
+                                </CollapsibleNavItem>
+                            </>
+                        )}
 
-                {mainNavItems.map(item => <NavItem key={item.to} {...item} isCollapsed={isCollapsed} />)}
+                        {mainNavItems.map(item => <NavItem key={item.to} {...item} isCollapsed={isCollapsed} />)}
+                    </div>
 
-                <SectionHeader label="Messages" isCollapsed={isCollapsed} />
-                {messages.map(msg => <MessageItem key={msg.name} {...msg} isCollapsed={isCollapsed} />)}
-            </nav>
+                    <div className={`${isCollapsed ? 'space-y-1' : 'space-y-2 rounded-2xl border border-white/10 bg-white/10 p-3 shadow-inner dark:border-slate-700/40 dark:bg-slate-900/35'}`}>
+                        <SectionHeader label="Messages" isCollapsed={isCollapsed} />
+                        {messages.map(msg => <MessageItem key={msg.name} {...msg} isCollapsed={isCollapsed} />)}
+                    </div>
+                </nav>
 
-            <div className="p-4 mt-auto relative z-10">
-                <AnimatePresence>
-                    {!isCollapsed && (
-                        <motion.div
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1, transition: { delay: 0.2 } }}
-                            exit={{ opacity: 0 }}
-                            className="bg-neutral-800/80 p-4 rounded-lg text-center border"
-                            style={{ borderColor: 'var(--color-sidebar-border)' }}
-                        >
-                            <h4 className="font-semibold text-white">Let's start!</h4>
-                            <p className="text-xs text-neutral-400 mt-1 mb-3">Creating or starting new tasks couldn't be easier.</p>
-                            <Link to="/create-post">
-                                <Button gradientDuoTone="purpleToBlue" className="w-full">
-                                    <FaPlus className="mr-2 h-3 w-3" /> Add New Task
-                                </Button>
-                            </Link>
-                        </motion.div>
-                    )}
-                </AnimatePresence>
-                <AnimatePresence>
-                    {isCollapsed && (
-                        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-                            <Link to="/create-post">
-                                <Button gradientDuoTone="purpleToBlue" className="w-full h-12 flex items-center justify-center rounded-lg"><FaPlus /></Button>
-                            </Link>
-                        </motion.div>
-                    )}
-                </AnimatePresence>
+                <div className="relative z-10 mt-auto px-4 pb-5">
+                    <AnimatePresence>
+                        {!isCollapsed && (
+                            <motion.div
+                                initial={{ opacity: 0, y: 12 }}
+                                animate={{ opacity: 1, y: 0, transition: { delay: 0.2 } }}
+                                exit={{ opacity: 0, y: 12 }}
+                                className="rounded-2xl border border-white/10 bg-gradient-to-br from-slate-900/75 via-slate-900/50 to-slate-900/80 p-5 text-center shadow-2xl"
+                            >
+                                <h4 className="text-base font-semibold text-white">Ready for your next sprint?</h4>
+                                <p className="mt-2 text-xs text-neutral-300">Create a task and keep your research momentum going.</p>
+                                <Link to="/create-post" className="mt-4 block">
+                                    <Button gradientDuoTone="purpleToBlue" className="w-full">
+                                        <FaPlus className="mr-2 h-3 w-3" /> New Task
+                                    </Button>
+                                </Link>
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
+                    <AnimatePresence>
+                        {isCollapsed && (
+                            <motion.div initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: 8 }}>
+                                <Tooltip content="Create a new task" placement="right">
+                                    <Link to="/create-post">
+                                        <Button gradientDuoTone="purpleToBlue" className="flex h-12 w-full items-center justify-center rounded-2xl">
+                                            <FaPlus />
+                                        </Button>
+                                    </Link>
+                                </Tooltip>
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
+                </div>
             </div>
         </motion.aside>
     );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@700;800&display=swap');
+
 /* client/src/index.css */
 @tailwind base;
 @tailwind components;
@@ -13,10 +16,6 @@
  * --- Fonts and Base Styles ---
  * Defines base font families and global rendering settings.
  */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@700;800&display=swap');
-
-
 body {
   height: 100vh;
   -webkit-font-smoothing: antialiased;
@@ -100,6 +99,12 @@ html {
   background-position: center;
   color: var(--color-text-primary);
   border-color: var(--color-sidebar-border);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--color-sidebar-border);
+  box-shadow: 0 40px 80px -60px rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
 }
 
 .dark .sidebar {
@@ -109,6 +114,34 @@ html {
   background-position: center;
   color: var(--color-text-primary);
   border-color: var(--color-sidebar-border);
+  box-shadow: 0 45px 90px -65px rgba(15, 23, 42, 0.95);
+}
+
+.sidebar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.04) 45%, rgba(255, 255, 255, 0) 100%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.dark .sidebar::before {
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.15) 0%, rgba(30, 41, 59, 0.15) 45%, rgba(15, 23, 42, 0) 100%);
+  mix-blend-mode: normal;
+}
+
+.sidebar::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+}
+
+.dark .sidebar::after {
+  border: 1px solid rgba(51, 65, 85, 0.45);
 }
 
 


### PR DESCRIPTION
## Summary
- redesign the main layout sidebar with gradient layers, refined nav items, and updated footer call-to-action for a more professional feel
- enhance sidebar message and profile sections with glassmorphism-inspired cards and cohesive hover treatments in collapsed mode
- move font imports to the top of the global stylesheet and expand sidebar CSS with backdrop blur, box-shadows, and decorative pseudo-elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8892df3788332a31da03380aaec63