### PR TITLE
Remove header theme toggle button

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -7,7 +7,6 @@ import { motion, AnimatePresence, useScroll, useMotionValueEvent } from 'framer-
 import { useEffect, useState, useRef } from 'react';
 
 import { signoutSuccess } from '../redux/user/userSlice';
-import ThemeToggle from './ThemeToggle.jsx';
 import CommandMenu from './CommandMenu';
 import ControlCenter from './ControlCenter.jsx';
 
@@ -220,11 +219,6 @@ export default function Header() {
                 </Magnetic>
                 <Magnetic>
                   <ControlCenter />
-                </Magnetic>
-                <Magnetic>
-                  <Tooltip content="Toggle Theme">
-                    <ThemeToggle className="hidden sm:inline-flex w-12 h-10" />
-                  </Tooltip>
                 </Magnetic>
                 {currentUser ? (
                     <div className="relative">


### PR DESCRIPTION
## Summary
- remove the theme toggle button from the main header and drop the unused import

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d8a75aa4a88332911d873d02aba03d