### PR TITLE
Fix focus selection handler initialization

### DIFF
--- a/client/src/components/ControlCenter.jsx
+++ b/client/src/components/ControlCenter.jsx
@@ -178,6 +178,21 @@ export default function ControlCenter() {
         return () => window.removeEventListener('keydown', handleGlobalShortcut);
     }, []);
 
+    const handleFocusSelection = (modeId) => {
+        setFocusMode(modeId);
+        const presets = {
+            off: { brightness: 80, volume: 60, doNotDisturb: false },
+            deep: { brightness: 65, volume: 35, doNotDisturb: true },
+            break: { brightness: 95, volume: 75, doNotDisturb: false },
+        };
+        const preset = presets[modeId];
+        if (preset) {
+            setBrightness(preset.brightness);
+            setVolume(preset.volume);
+            setDoNotDisturb(preset.doNotDisturb);
+        }
+    };
+
     const searchItems = useMemo(
         () => [
             {
@@ -320,21 +335,6 @@ export default function ControlCenter() {
     const handleSearchSelect = (item) => {
         item.action?.();
         setSearchQuery('');
-    };
-
-    const handleFocusSelection = (modeId) => {
-        setFocusMode(modeId);
-        const presets = {
-            off: { brightness: 80, volume: 60, doNotDisturb: false },
-            deep: { brightness: 65, volume: 35, doNotDisturb: true },
-            break: { brightness: 95, volume: 75, doNotDisturb: false },
-        };
-        const preset = presets[modeId];
-        if (preset) {
-            setBrightness(preset.brightness);
-            setVolume(preset.volume);
-            setDoNotDisturb(preset.doNotDisturb);
-        }
     };
 
     const handleReset = () => {


### PR DESCRIPTION
## Summary
- define the focus selection handler before memoized search items to avoid temporal dead zone errors
- preserve existing focus presets while ensuring search item actions can call the handler safely

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d8ad2697788332a71afd3737840204