### PR TITLE
Remove dashboard and message sections from sidebar

### DIFF
--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -1,14 +1,11 @@
-import { NavLink, Link, useLocation } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { motion, AnimatePresence, useMotionValue } from 'framer-motion';
-import React, { useState, useEffect, useRef } from 'react';
 import {
     FaBook,
-    FaChevronDown,
     FaProjectDiagram,
     FaQuestionCircle,
     FaSignInAlt,
-    FaTachometerAlt,
     FaPlus,
     FaRegBell,
     FaRegFileAlt,
@@ -93,108 +90,6 @@ const NavItem = ({ to, icon: Icon, label, isCollapsed }) => (
     </Tooltip>
 );
 
-const CollapsibleNavItem = ({ icon: Icon, label, isCollapsed, children }) => {
-    const [isInlineOpen, setIsInlineOpen] = useState(true);
-    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-    const ref = useRef(null);
-    const location = useLocation();
-
-    // Check if any child link is the active route
-    const isActive = React.Children.toArray(children).some(child =>
-        child.props.to && location.pathname.startsWith(child.props.to.split('?')[0])
-    );
-
-    return (
-        <div
-            ref={ref}
-            onMouseEnter={() => isCollapsed && setIsPopoverOpen(true)}
-            onMouseLeave={() => isCollapsed && setIsPopoverOpen(false)}
-            className="relative"
-        >
-            <Tooltip content={label} placement="right" animation="duration-300" disabled={!isCollapsed}>
-                <motion.button
-                    whileHover={!isCollapsed ? { x: 5, backgroundColor: 'rgba(100, 116, 139, 0.1)' } : {}}
-                    transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-                    onClick={() => !isCollapsed && setIsInlineOpen(!isInlineOpen)}
-                    className={`flex items-center gap-3 w-full px-3 py-2.5 rounded-lg font-medium text-left transition-colors duration-200 text-base relative ${
-                        (isActive || isInlineOpen && !isCollapsed) ? 'bg-neutral-700/30 text-white' : 'text-neutral-400 hover:text-white'
-                    } ${isCollapsed ? 'justify-center px-0' : ''}`}
-                >
-                    <AnimatePresence>
-                        {isActive && (
-                            <motion.div
-                                layoutId="active-nav-item-indicator"
-                                className="absolute left-0 top-2 bottom-2 w-1 bg-accent-teal rounded-r-full"
-                            />
-                        )}
-                    </AnimatePresence>
-                    <motion.div whileHover={{ scale: 1.1 }}>
-                        <Icon className="h-5 w-5 flex-shrink-0" />
-                    </motion.div>
-                    {!isCollapsed && <span className="flex-1 whitespace-nowrap">{label}</span>}
-                    {!isCollapsed && (
-                        <motion.div animate={{ rotate: isInlineOpen ? 0 : -90 }} transition={{ duration: 0.2 }}>
-                            <FaChevronDown size={12} />
-                        </motion.div>
-                    )}
-                </motion.button>
-            </Tooltip>
-
-            <AnimatePresence>
-                {!isCollapsed && isInlineOpen && (
-                    <motion.div
-                        initial={{ height: 0, opacity: 0 }}
-                        animate={{ height: 'auto', opacity: 1 }}
-                        exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.3, ease: 'easeInOut' }}
-                        className="overflow-hidden ml-4 pl-[1.1rem] border-l border-neutral-700"
-                    >
-                        <div className="pt-1 flex flex-col gap-1">{children}</div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
-
-            <AnimatePresence>
-                {isCollapsed && isPopoverOpen && (
-                    <motion.div
-                        initial={{ opacity: 0, scale: 0.95, x: -10 }}
-                        animate={{ opacity: 1, scale: 1, x: 0 }}
-                        exit={{ opacity: 0, scale: 0.95, x: -10 }}
-                        transition={{ duration: 0.2 }}
-                        className="absolute left-full top-0 ml-2 bg-neutral-800/90 backdrop-blur-sm p-2 rounded-lg shadow-xl w-40 border border-neutral-700 z-50"
-                    >
-                        {children}
-                    </motion.div>
-                )}
-            </AnimatePresence>
-        </div>
-    );
-};
-
-const MessageItem = ({ name, avatar, isCollapsed }) => (
-    <Link to="#">
-        <motion.div
-            whileHover={!isCollapsed ? { x: 5, backgroundColor: 'rgba(100, 116, 139, 0.1)' } : {}}
-            transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-            className="flex items-center gap-3 px-3 py-2 rounded-lg text-neutral-400 hover:text-white transition-colors">
-            <Avatar img={avatar} rounded size="xs" />
-            <AnimatePresence>
-                {!isCollapsed && (
-                    <motion.span
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        className="whitespace-nowrap text-sm"
-                    >
-                        {name}
-                    </motion.span>
-                )}
-            </AnimatePresence>
-        </motion.div>
-    </Link>
-);
-
-
 // --- Main Sidebar Component ---
 const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
     const { currentUser } = useSelector((state) => state.user);
@@ -217,33 +112,6 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
         { to: '/wallet', label: 'Wallet', icon: FaRegCreditCard },
         { to: '/notification', label: 'Notification', icon: FaRegBell },
     ];
-
-    const messages = [
-        { name: 'Erik Gunsel', avatar: 'https://i.pravatar.cc/150?u=erik' },
-        { name: 'Emily Smith', avatar: 'https://i.pravatar.cc/150?u=emily' },
-        { name: 'Arthur Adell', avatar: 'https://i.pravatar.cc/150?u=arthur' },
-    ];
-
-    // FIX: This component now correctly handles not having an icon.
-    const SubItem = ({ to, label }) => (
-        <Tooltip content={label} placement="right" animation="duration-300" disabled={!isCollapsed}>
-            <NavLink to={to}>
-                {({ isActive }) => (
-                    <motion.div
-                        whileHover={{ x: 5, backgroundColor: 'rgba(100, 116, 139, 0.1)' }}
-                        transition={{ type: 'spring', stiffness: 400, damping: 15 }}
-                        className={`flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors duration-200 relative ${
-                            isActive ? 'bg-neutral-700/50 text-white' : 'text-neutral-400 hover:text-white'
-                        }`}
-                    >
-                        {isActive && <motion.div layoutId="active-nav-item-indicator" className="absolute left-0 top-1 bottom-1 w-0.5 bg-accent-teal rounded-r-full" />}
-                        {!isCollapsed && <span>{label}</span>}
-                    </motion.div>
-                )}
-            </NavLink>
-        </Tooltip>
-    );
-
 
     return (
         <motion.aside
@@ -309,29 +177,15 @@ const Sidebar = ({ isCollapsed, isPinned, setIsPinned }) => {
             <nav className="flex-1 p-2 space-y-1 overflow-y-auto">
                 <SectionHeader label="Main" isCollapsed={isCollapsed} />
                 {currentUser?.isAdmin && (
-                    <>
-                        <NavItem
-                            to="/admin"
-                            icon={FaShieldAlt}
-                            label="Admin Panel"
-                            isCollapsed={isCollapsed}
-                        />
-                        <CollapsibleNavItem icon={FaTachometerAlt} label="Dashboard" isCollapsed={isCollapsed}>
-                            <SubItem to="/dashboard?tab=dash" label="Overview" />
-                            <SubItem to="/dashboard?tab=posts" label="Posts" />
-                            <SubItem to="/dashboard?tab=tutorials" label="Tutorials" />
-                            <SubItem to="/dashboard?tab=quizzes" label="Quizzes" />
-                            <SubItem to="/dashboard?tab=content" label="Content" />
-                            <SubItem to="/dashboard?tab=comments" label="Comments" />
-                            <SubItem to="/dashboard?tab=users" label="Users" />
-                        </CollapsibleNavItem>
-                    </>
+                    <NavItem
+                        to="/admin"
+                        icon={FaShieldAlt}
+                        label="Admin Panel"
+                        isCollapsed={isCollapsed}
+                    />
                 )}
 
                 {mainNavItems.map(item => <NavItem key={item.to} {...item} isCollapsed={isCollapsed} />)}
-
-                <SectionHeader label="Messages" isCollapsed={isCollapsed} />
-                {messages.map(msg => <MessageItem key={msg.name} {...msg} isCollapsed={isCollapsed} />)}
             </nav>
 
             <div className="p-4 mt-auto relative z-10">


### PR DESCRIPTION
## Summary
- remove the dashboard collapsible menu and message list from the main sidebar
- streamline the sidebar component by deleting now-unused helper components and imports

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_b_68d9e1ba90b08332a4c58a57f8a25176