### PR TITLE
Adjust sidebar positioning to scroll with page

### DIFF
--- a/client/src/components/MainLayout.jsx
+++ b/client/src/components/MainLayout.jsx
@@ -79,9 +79,8 @@ export default function MainLayout() {
                 </motion.div>
 
                 <motion.main
-                    className="flex-1 min-h-screen"
-                    animate={{ marginLeft: isSidebarCollapsed ? '5rem' : `${sidebarWidth}px` }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                    className="flex-1 min-h-screen transition-all duration-300"
+                    style={{ marginLeft: 0 }}
                 >
                     <AnimatePresence mode="wait">
                         <motion.div

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -160,7 +160,7 @@ const Sidebar = ({ isCollapsed, isPinned, onTogglePin, onToggleCollapse, expande
         <motion.aside
             animate={{ width: isCollapsed ? '5rem' : sidebarTargetWidth }}
             transition={{ duration: 0.3, ease: [0.42, 0, 0.58, 1] }}
-            className="sidebar hidden md:flex flex-col fixed top-0 left-0 z-40 h-[calc(100vh-2rem)] my-4 ml-4 rounded-2xl border backdrop-blur-lg bg-white/60 dark:bg-slate-900/60 shadow-lg"
+            className="sidebar hidden md:flex flex-col relative z-40 min-h-[calc(100vh-2rem)] my-4 ml-4 rounded-2xl border backdrop-blur-lg bg-white/60 dark:bg-slate-900/60 shadow-lg"
             onMouseMove={handleMouseMove}
         >
             <motion.div


### PR DESCRIPTION
## Summary
- remove the fixed positioning from the sidebar so it scrolls with the rest of the page
- rely on the flex layout for main content spacing instead of margin animations when the sidebar resizes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d9f2785c3c8332a98034556506de41