### PR TITLE
Remove sidebar from layouts

### DIFF
--- a/client/src/components/MainLayout.jsx
+++ b/client/src/components/MainLayout.jsx
@@ -1,87 +1,20 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { useState, useEffect } from 'react';
 
 import Header from './Header';
 import Footer from './Footer';
 import ScrollToTop from './ScrollToTop';
 import BottomNav from './BottomNav';
-import Sidebar from './Sidebar';
-import useResizable from '../hooks/useResizable'; // Hook for resizable sidebar
 
 export default function MainLayout() {
     const location = useLocation();
-
-    // Sidebar State
-    const [isPinned, setIsPinned] = useState(() =>
-        JSON.parse(localStorage.getItem('sidebar-pinned')) || false
-    );
-    const [isCollapsedExplicit, setIsCollapsedExplicit] = useState(() =>
-        JSON.parse(localStorage.getItem('sidebar-collapsed')) || false
-    );
-    const [isHovering, setIsHovering] = useState(false);
-
-    // Resizable Sidebar Hook
-    const { width: sidebarWidth, isResizing, startResizing } = useResizable(256, 220, 400);
-
-    useEffect(() => {
-        localStorage.setItem('sidebar-pinned', JSON.stringify(isPinned));
-    }, [isPinned]);
-
-    useEffect(() => {
-        localStorage.setItem('sidebar-collapsed', JSON.stringify(isCollapsedExplicit));
-    }, [isCollapsedExplicit]);
-
-    const isSidebarCollapsed = isCollapsedExplicit || (!isPinned && !isHovering);
-    const currentSidebarWidth = isSidebarCollapsed ? 80 : sidebarWidth;
-
-    const handleTogglePin = () => {
-        setIsPinned(prevIsPinned => {
-            const nextIsPinned = !prevIsPinned;
-
-            if (nextIsPinned) {
-                setIsCollapsedExplicit(false);
-            }
-
-            return nextIsPinned;
-        });
-    };
-
-    const handleToggleCollapse = () => {
-        setIsCollapsedExplicit(prev => !prev);
-    };
 
     return (
         <>
             <ScrollToTop />
             <Header />
-            <div className="flex pt-20"> {/* Add padding top to account for fixed header */}
-                <motion.div
-                    onMouseEnter={() => setIsHovering(true)}
-                    onMouseLeave={() => setIsHovering(false)}
-                    className="relative z-40 hidden md:block group"
-                    animate={{ width: currentSidebarWidth }}
-                    transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                >
-                    <Sidebar
-                        isCollapsed={isSidebarCollapsed}
-                        isPinned={isPinned}
-                        onTogglePin={handleTogglePin}
-                        onToggleCollapse={handleToggleCollapse}
-                        expandedWidth={sidebarWidth}
-                    />
-                    <div
-                        onMouseDown={startResizing}
-                        className={`absolute top-0 right-0 h-full w-2 cursor-col-resize select-none transition-opacity duration-200 ${
-                            isSidebarCollapsed ? 'pointer-events-none opacity-0' : 'opacity-0 group-hover:opacity-100'
-                        } ${isResizing ? 'bg-blue-500/50' : 'bg-transparent hover:bg-blue-500/30'}`}
-                    />
-                </motion.div>
-
-                <motion.main
-                    className="flex-1 min-h-screen transition-all duration-300"
-                    style={{ marginLeft: 0 }}
-                >
+            <div className="pt-20">
+                <motion.main className="min-h-screen transition-all duration-300">
                     <AnimatePresence mode="wait">
                         <motion.div
                             key={location.pathname}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -2,7 +2,6 @@
 import { useEffect, useState, lazy, Suspense } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Spinner } from 'flowbite-react';
-import DashSidebar from '../components/DashSidebar';
 import { useSelector } from 'react-redux';
 
 // Dynamically import components using React.lazy
@@ -12,7 +11,7 @@ const DashUsers = lazy(() => import('../components/DashUsers'));
 const DashComments = lazy(() => import('../components/DashComments'));
 const DashboardComp = lazy(() => import('../components/DashboardComp'));
 const DashTutorials = lazy(() => import('../components/DashTutorials'));
-const DashQuizzes = lazy(() => import('../components/DashQuizzes')); // NEW: Import DashQuizzes component
+const DashQuizzes = lazy(() => import('../components/DashQuizzes'));
 const DashPages = lazy(() => import('../components/DashPages'));
 const DashProblems = lazy(() => import('../components/DashProblems'));
 
@@ -24,7 +23,7 @@ const componentMap = {
     comments: DashComments,
     dash: DashboardComp,
     tutorials: DashTutorials,
-    quizzes: DashQuizzes, // NEW: Add DashQuizzes to the map
+    quizzes: DashQuizzes,
     content: DashPages,
     problems: DashProblems,
 };
@@ -44,22 +43,16 @@ export default function Dashboard() {
     const ActiveComponent = componentMap[tab];
 
     return (
-        <div className='min-h-screen flex flex-col md:flex-row'>
-            <div className='md:w-56'>
-                <DashSidebar />
-            </div>
-
-            <main className='w-full'>
-                <Suspense
-                    fallback={
-                        <div className='flex justify-center items-center min-h-screen w-full'>
-                            <Spinner size='xl' />
-                        </div>
-                    }
-                >
-                    {ActiveComponent && <ActiveComponent />}
-                </Suspense>
-            </main>
+        <div className='min-h-screen w-full'>
+            <Suspense
+                fallback={
+                    <div className='flex justify-center items-center min-h-screen w-full'>
+                        <Spinner size='xl' />
+                    </div>
+                }
+            >
+                {ActiveComponent && <ActiveComponent />}
+            </Suspense>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- remove the global layout sidebar and associated state management
- simplify the dashboard page by eliminating the admin sidebar wrapper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d9f77793bc8332a323aa00dced5a0c