### PR TITLE
Fix bottom dock navigation visibility

### DIFF
--- a/client/src/components/BottomNav.jsx
+++ b/client/src/components/BottomNav.jsx
@@ -24,9 +24,9 @@ export default function BottomNav() {
         'bg-white/80 dark:bg-gray-800/80 text-gray-600 dark:text-gray-200 shadow-md shadow-gray-900/10';
 
     return (
-        <nav className="fixed bottom-6 left-1/2 z-50 flex w-full max-w-4xl -translate-x-1/2 justify-center px-4 pointer-events-none">
+        <nav className="fixed bottom-6 left-1/2 z-50 flex w-full max-w-4xl -translate-x-1/2 justify-center px-4">
             <motion.ul
-                className="pointer-events-auto flex items-end gap-4 rounded-3xl border border-white/30 bg-white/70 p-3 backdrop-blur-xl shadow-2xl shadow-cyan-500/20 dark:border-white/10 dark:bg-gray-900/60"
+                className="flex items-end gap-4 rounded-3xl border border-white/30 bg-white/70 p-3 backdrop-blur-xl shadow-2xl shadow-cyan-500/20 dark:border-white/10 dark:bg-gray-900/60"
                 initial={{ opacity: 0, y: 40 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.35, ease: 'easeOut' }}


### PR DESCRIPTION
## Summary
- remove the pointer-events override on the floating bottom navigation wrapper so the dock renders as expected
- rely on the inner motion list for interaction styling while keeping the dock visible across routes

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68da02ea3e6c8332ba33629c0c3444f1