### PR TITLE
feat: restyle dock navigation with custom icons

### DIFF
--- a/client/src/assets/dock/dashboard.svg
+++ b/client/src/assets/dock/dashboard.svg
@@ -1,0 +1,18 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="dashboard-gradient" x1="20" y1="12" x2="60" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8" />
+      <stop offset="1" stop-color="#16A34A" />
+    </linearGradient>
+    <linearGradient id="dashboard-bars" x1="30" y1="24" x2="50" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.88" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.26" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#dashboard-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <rect x="26" y="34" width="8" height="20" rx="3" fill="url(#dashboard-bars)" />
+  <rect x="36" y="26" width="8" height="28" rx="3" fill="url(#dashboard-bars)" />
+  <rect x="46" y="30" width="8" height="24" rx="3" fill="url(#dashboard-bars)" />
+  <path d="M26 30C26 28.3431 27.3431 27 29 27H51C52.6569 27 54 28.3431 54 30V32H26V30Z" fill="#0F172A" fill-opacity="0.15" />
+</svg>

--- a/client/src/assets/dock/home.svg
+++ b/client/src/assets/dock/home.svg
@@ -1,0 +1,17 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="home-gradient" x1="20" y1="12" x2="60" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6EE7FF" />
+      <stop offset="1" stop-color="#1D4ED8" />
+    </linearGradient>
+    <linearGradient id="home-roof" x1="40" y1="22" x2="40" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.2" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#home-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.28" stroke-width="1.5" />
+  <path d="M40 22L20 38.5L24.6 44H27V58H36.5V45.5C36.5 44.1193 37.6193 43 39 43H41C42.3807 43 43.5 44.1193 43.5 45.5V58H53V44H55.4L60 38.5L40 22Z" fill="url(#home-roof)" />
+  <path d="M40 24.6L23.2 38.6L26 42H30V56H35.5V45.5C35.5 43.2909 37.2909 41.5 39.5 41.5H40.5C42.7091 41.5 44.5 43.2909 44.5 45.5V56H50V42H54L56.8 38.6L40 24.6Z" fill="#0F172A" fill-opacity="0.14" />
+  <path d="M40 20L18 38.4L22.6 44L40 29L57.4 44L62 38.4L40 20Z" fill="#FFFFFF" fill-opacity="0.24" />
+</svg>

--- a/client/src/assets/dock/problems.svg
+++ b/client/src/assets/dock/problems.svg
@@ -1,0 +1,17 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="problems-gradient" x1="18" y1="12" x2="62" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FB7185" />
+      <stop offset="1" stop-color="#6366F1" />
+    </linearGradient>
+    <linearGradient id="problems-bulb" x1="32" y1="20" x2="48" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.92" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.3" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#problems-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <path d="M40 20C32.8203 20 27 25.8203 27 33C27 37.651 29.2431 41.7968 32.9104 44.148C34.1657 44.9733 34.9196 46.3393 34.9196 47.8091V50.5C34.9196 51.8807 36.0389 53 37.4196 53H42.5804C43.9611 53 45.0804 51.8807 45.0804 50.5V47.8091C45.0804 46.3393 45.8343 44.9733 47.0896 44.148C50.7569 41.7968 53 37.651 53 33C53 25.8203 47.1797 20 40 20Z" fill="url(#problems-bulb)" />
+  <path d="M34 56C34 54.8954 34.8954 54 36 54H44C45.1046 54 46 54.8954 46 56C46 57.1046 45.1046 58 44 58H36C34.8954 58 34 57.1046 34 56Z" fill="#F8FAFC" fill-opacity="0.7" />
+  <path d="M38 61C38 59.8954 38.8954 59 40 59C41.1046 59 42 59.8954 42 61C42 62.1046 41.1046 63 40 63C38.8954 63 38 62.1046 38 61Z" fill="#F8FAFC" fill-opacity="0.7" />
+</svg>

--- a/client/src/assets/dock/quick-add.svg
+++ b/client/src/assets/dock/quick-add.svg
@@ -1,0 +1,16 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="quick-add-gradient" x1="22" y1="14" x2="58" y2="66" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F472B6" />
+      <stop offset="1" stop-color="#4C1D95" />
+    </linearGradient>
+    <linearGradient id="quick-add-plus" x1="40" y1="24" x2="40" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.95" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.3" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#quick-add-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <path d="M36 24H44V36H56V44H44V56H36V44H24V36H36V24Z" fill="url(#quick-add-plus)" />
+  <path d="M37.5 25.5H42.5V37.5H54.5V42.5H42.5V54.5H37.5V42.5H25.5V37.5H37.5V25.5Z" fill="#0F172A" fill-opacity="0.14" />
+</svg>

--- a/client/src/assets/dock/quizzes.svg
+++ b/client/src/assets/dock/quizzes.svg
@@ -1,0 +1,17 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="quizzes-gradient" x1="18" y1="14" x2="64" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FACC15" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+    <linearGradient id="quizzes-mark" x1="32" y1="22" x2="48" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.25" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#quizzes-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <path d="M40 22C33.9249 22 29 26.5483 29 32.2C29 34.5974 30.1002 37.0523 31.9719 38.6485C34.2558 40.5722 35.2 42.0995 35.2 44.8V46.4H44.8V44.8C44.8 41.9694 43.6491 39.806 41.4534 37.994C39.4865 36.3797 38.8 35.2391 38.8 33.6C38.8 31.6122 40.5242 30 42.6 30C44.6758 30 46.4 31.6122 46.4 33.6C46.4 35.1123 45.5725 36.4983 44.0863 37.3948L47.6 41.2C50.3597 39.4621 52 36.5601 52 33.6C52 27.454 46.5104 22 40 22Z" fill="url(#quizzes-mark)" />
+  <circle cx="40" cy="55" r="4" fill="#FFFFFF" fill-opacity="0.85" />
+  <circle cx="40" cy="55" r="4" fill="#0F172A" fill-opacity="0.12" />
+</svg>

--- a/client/src/assets/dock/theme.svg
+++ b/client/src/assets/dock/theme.svg
@@ -1,0 +1,22 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="theme-gradient" x1="24" y1="12" x2="56" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#22D3EE" />
+      <stop offset="1" stop-color="#3B82F6" />
+    </linearGradient>
+    <linearGradient id="theme-sun" x1="32" y1="24" x2="44" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FDE68A" />
+      <stop offset="1" stop-color="#FBBF24" />
+    </linearGradient>
+    <linearGradient id="theme-moon" x1="44" y1="28" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#E0E7FF" />
+      <stop offset="1" stop-color="#A5B4FC" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#theme-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <circle cx="36" cy="36" r="10" fill="url(#theme-sun)" />
+  <path d="M36 24C29.3726 24 24 29.3726 24 36C24 42.6274 29.3726 48 36 48C30.4772 44.4857 30.4772 27.5143 36 24Z" fill="#F8FAFC" fill-opacity="0.6" />
+  <path d="M44.5 30C46.9853 30 49 32.0147 49 34.5C49 39.1944 45.1944 43 40.5 43C38.0147 43 36 40.9853 36 38.5C36 33.8056 39.8056 30 44.5 30Z" fill="url(#theme-moon)" />
+  <circle cx="36" cy="36" r="14" stroke="#FFFFFF" stroke-opacity="0.3" stroke-width="2" stroke-dasharray="6 6" />
+</svg>

--- a/client/src/assets/dock/tools.svg
+++ b/client/src/assets/dock/tools.svg
@@ -1,0 +1,16 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="tools-gradient" x1="18" y1="14" x2="62" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#34D399" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+    <linearGradient id="tools-icon" x1="30" y1="24" x2="52" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.88" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.3" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#tools-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <path d="M30.5 24C29.1193 24 28 25.1193 28 26.5V33.5C28 34.8807 29.1193 36 30.5 36H33.0858L26.2929 42.7929C25.9024 43.1834 25.9024 43.8166 26.2929 44.2071L35.7929 53.7071C36.1834 54.0976 36.8166 54.0976 37.2071 53.7071L44 46.9142V49.5C44 50.8807 45.1193 52 46.5 52H53.5C54.8807 52 56 50.8807 56 49.5V44.5858C56 43.837 55.7018 43.1203 55.1716 42.5858L44.4142 31.8284C43.8839 31.2982 43.167 31 42.4142 31H37.5C35.567 31 33.794 30.109 32.5858 28.7426L31.4142 27.3574C31.1483 27.0503 30.8256 26.8109 30.4692 26.6592C30.3263 26.5998 30.5 24 30.5 24Z" fill="url(#tools-icon)" />
+  <path d="M37.5858 33L29.5 41.0858L38.9142 50.5L47 42.4142L37.5858 33Z" fill="#0F172A" fill-opacity="0.12" />
+</svg>

--- a/client/src/assets/dock/tutorials.svg
+++ b/client/src/assets/dock/tutorials.svg
@@ -1,0 +1,20 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="tutorials-gradient" x1="18" y1="12" x2="66" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F97316" />
+      <stop offset="1" stop-color="#C026D3" />
+    </linearGradient>
+    <linearGradient id="tutorials-pages" x1="24" y1="24" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.95" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.35" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#tutorials-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <path d="M25 24H38C41.3137 24 44 26.6863 44 30V56C44 52.6863 41.3137 50 38 50H25V24Z" fill="url(#tutorials-pages)" />
+  <path d="M55 24H42C38.6863 24 36 26.6863 36 30V56C36 52.6863 38.6863 50 42 50H55V24Z" fill="#FFE7FF" fill-opacity="0.5" />
+  <path d="M25 24H55V28H25V24Z" fill="#0F172A" fill-opacity="0.15" />
+  <path d="M31 34H48" stroke="#1F2937" stroke-width="2" stroke-linecap="round" stroke-opacity="0.28" />
+  <path d="M31 40H48" stroke="#1F2937" stroke-width="2" stroke-linecap="round" stroke-opacity="0.24" />
+  <path d="M31 46H45" stroke="#1F2937" stroke-width="2" stroke-linecap="round" stroke-opacity="0.2" />
+</svg>

--- a/client/src/assets/dock/visualizer.svg
+++ b/client/src/assets/dock/visualizer.svg
@@ -1,0 +1,25 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="visualizer-gradient" x1="20" y1="12" x2="60" y2="68" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A855F7" />
+      <stop offset="1" stop-color="#2563EB" />
+    </linearGradient>
+    <linearGradient id="visualizer-screen" x1="24" y1="24" x2="56" y2="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.92" />
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.25" />
+    </linearGradient>
+    <linearGradient id="visualizer-graph" x1="28" y1="32" x2="52" y2="48" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8" />
+      <stop offset="1" stop-color="#14B8A6" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="68" height="68" rx="22" fill="url(#visualizer-gradient)" />
+  <rect x="6" y="6" width="68" height="68" rx="22" stroke="white" stroke-opacity="0.32" stroke-width="1.5" />
+  <rect x="22" y="22" width="36" height="28" rx="8" fill="url(#visualizer-screen)" />
+  <path d="M26 48H54V50C54 52.2091 52.2091 54 50 54H30C27.7909 54 26 52.2091 26 50V48Z" fill="#0F172A" fill-opacity="0.18" />
+  <path d="M30 40L35 36L40 42L47 34L50 38" stroke="url(#visualizer-graph)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="35" cy="36" r="2.5" fill="#38BDF8" />
+  <circle cx="40" cy="42" r="2.5" fill="#14B8A6" />
+  <circle cx="47" cy="34" r="2.5" fill="#38BDF8" />
+  <circle cx="50" cy="38" r="2.5" fill="#14B8A6" />
+</svg>

--- a/client/src/components/BottomNav.jsx
+++ b/client/src/components/BottomNav.jsx
@@ -1,37 +1,22 @@
+import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
-import {
-    FaBook,
-    FaHome,
-    FaQuestionCircle,
-    FaUser,
-    FaLaptopCode,
-    FaLightbulb,
-    FaTools,
-    FaPlus,
-    FaPenFancy,
-    FaLayerGroup,
-    FaUserPlus,
-    FaChevronRight,
-} from 'react-icons/fa';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ThemeToggle from './ThemeToggle.jsx';
+import {
+    baseDockItems,
+    dashboardDockItem,
+    quickAddDockItem,
+    themeDockItem,
+} from '../data/dockItems';
+import { toggleTheme } from '../redux/theme/themeSlice';
 
-const baseItems = [
-    { to: '/', label: 'Home', icon: FaHome, match: (path) => path === '/' },
-    { to: '/tutorials', label: 'Tutorials', icon: FaBook, match: (path) => path.startsWith('/tutorials') },
-    { to: '/quizzes', label: 'Quizzes', icon: FaQuestionCircle, match: (path) => path.startsWith('/quizzes') },
-    { to: '/tools', label: 'Tools', icon: FaTools, match: (path) => path.startsWith('/tools') },
-    { to: '/problems', label: 'Problems', icon: FaLightbulb, match: (path) => path.startsWith('/problems') },
-    { to: '/visualizer', label: 'Code Visualizer', icon: FaLaptopCode, match: (path) => path.startsWith('/visualizer') },
-];
-
+const ICON_CONTAINER_BASE =
+    'relative flex h-16 w-16 items-center justify-center rounded-[22px] transition-all duration-300 backdrop-blur-2xl';
 const ACTIVE_CLASSES =
-    'bg-gradient-to-br from-cyan-400 via-sky-500 to-blue-600 text-white shadow-[0_22px_45px_-18px_rgba(14,165,233,0.65)] ring-2 ring-white/70 dark:ring-slate-100/15';
+    'bg-white/80 shadow-[0_26px_45px_-20px_rgba(56,189,248,0.65)] ring-2 ring-white/60 dark:bg-slate-900/70 dark:ring-slate-100/20 dark:shadow-[0_26px_45px_-24px_rgba(148,163,184,0.65)]';
 const INACTIVE_CLASSES =
-    'bg-white/80 text-slate-600 shadow-[0_24px_40px_-20px_rgba(15,23,42,0.45)] ring-1 ring-white/70 backdrop-blur-xl dark:bg-slate-900/70 dark:text-slate-200 dark:shadow-[0_24px_40px_-22px_rgba(148,163,184,0.45)] dark:ring-slate-100/15';
-
+    'bg-white/40 ring-1 ring-white/45 shadow-[0_24px_40px_-22px_rgba(15,23,42,0.55)] dark:bg-slate-900/55 dark:ring-slate-100/10 dark:shadow-[0_24px_40px_-24px_rgba(15,23,42,0.65)]';
 const DOCK_INFLUENCE_DISTANCE = 160;
 
 const ADMIN_QUICK_ADD_OPTIONS = [
@@ -39,25 +24,25 @@ const ADMIN_QUICK_ADD_OPTIONS = [
         to: '/create-post',
         label: 'New Post',
         description: 'Share a fresh insight or announcement with the community.',
-        icon: FaPenFancy,
+        illustration: 'post',
     },
     {
         to: '/create-tutorial',
         label: 'New Tutorial',
         description: 'Design a guided learning journey in minutes.',
-        icon: FaLayerGroup,
+        illustration: 'tutorial',
     },
     {
         to: '/create-quiz',
         label: 'New Quiz',
         description: 'Build an interactive assessment for your learners.',
-        icon: FaQuestionCircle,
+        illustration: 'quiz',
     },
     {
         to: '/create-problem',
         label: 'New Problem',
         description: 'Add a fresh coding challenge for practice.',
-        icon: FaLightbulb,
+        illustration: 'problem',
     },
 ];
 
@@ -66,19 +51,19 @@ const BASE_QUICK_ADD_OPTIONS = [
         to: '/quizzes',
         label: 'Practice Quiz',
         description: 'Jump straight into a timed knowledge check.',
-        icon: FaQuestionCircle,
+        illustration: 'quiz',
     },
     {
         to: '/problems',
         label: 'Solve a Problem',
         description: 'Sharpen your skills with curated exercises.',
-        icon: FaLightbulb,
+        illustration: 'problem',
     },
     {
         to: '/tools',
         label: 'Open Tools',
         description: 'Launch compilers, sandboxes, and utilities.',
-        icon: FaTools,
+        illustration: 'tools',
     },
 ];
 
@@ -86,29 +71,151 @@ const GUEST_QUICK_ADD_OPTION = {
     to: '/sign-up',
     label: 'Invite a Collaborator',
     description: 'Create an account to co-build alongside your team.',
-    icon: FaUserPlus,
+    illustration: 'invite',
+};
+
+const QuickAddIllustration = ({ variant }) => {
+    switch (variant) {
+        case 'post':
+            return (
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5">
+                    <path
+                        d="M4.75 5.75C4.75 4.7835 5.5335 4 6.5 4H13L18.75 9.75V18.25C18.75 19.2165 17.9665 20 17 20H6.5C5.5335 20 4.75 19.2165 4.75 18.25V5.75Z"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinejoin="round"
+                    />
+                    <path d="M13 4V8.5C13 9.32843 13.6716 10 14.5 10H18.75" stroke="currentColor" strokeWidth="1.6" />
+                    <path d="M7.5 13H15.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                    <path d="M7.5 16H12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                </svg>
+            );
+        case 'tutorial':
+            return (
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5">
+                    <path
+                        d="M6.5 6H11.5C12.6046 6 13.5 6.89543 13.5 8V19C13.5 17.8954 12.6046 17 11.5 17H6.5V6Z"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinejoin="round"
+                    />
+                    <path
+                        d="M17.5 6H12.5C11.3954 6 10.5 6.89543 10.5 8V19C10.5 17.8954 11.3954 17 12.5 17H17.5V6Z"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinejoin="round"
+                    />
+                    <path d="M7.5 9.5H12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                    <path d="M7.5 13H11.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                </svg>
+            );
+        case 'quiz':
+            return (
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5">
+                    <path
+                        d="M12 5.25C9.37665 5.25 7.25 7.37665 7.25 10C7.25 11.4255 7.93537 12.7261 9.0294 13.6031C10.3026 14.6152 10.75 15.3322 10.75 16.75V18"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                    />
+                    <path
+                        d="M12 19.75C11.3096 19.75 10.75 19.1904 10.75 18.5C10.75 17.8096 11.3096 17.25 12 17.25C12.6904 17.25 13.25 17.8096 13.25 18.5C13.25 19.1904 12.6904 19.75 12 19.75Z"
+                        fill="currentColor"
+                    />
+                    <path
+                        d="M12 5.25C14.6234 5.25 16.75 7.37665 16.75 10C16.75 11.5442 15.9958 12.7958 14.5 13.75"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                    />
+                </svg>
+            );
+        case 'problem':
+            return (
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5">
+                    <path
+                        d="M12 5C9.23858 5 7 7.23858 7 10C7 11.9952 8.16377 13.7349 9.92077 14.5565C10.6141 14.8798 11.031 15.5805 11.031 16.3418V17.25"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                    />
+                    <path d="M10 19H14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                    <path
+                        d="M13 16.5C13 15.6716 13.6716 15 14.5 15C16.433 15 18 13.433 18 11.5C18 9.567 16.433 8 14.5 8C14.0071 8 13.5418 8.12041 13.125 8.33579"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                    />
+                </svg>
+            );
+        case 'tools':
+            return (
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5">
+                    <path
+                        d="M8.75 5.75L7 7.5L9.25 9.75L7.75 11.25L4.75 8.25L6.5 6.5"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                    <path
+                        d="M13.5 7L18.25 11.75L14.75 15.25L10 10.5"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                    <path d="M12 15.5L15 18.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                </svg>
+            );
+        case 'invite':
+        default:
+            return (
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5">
+                    <path
+                        d="M12 6.5C13.6569 6.5 15 7.84315 15 9.5C15 11.1569 13.6569 12.5 12 12.5C10.3431 12.5 9 11.1569 9 9.5C9 7.84315 10.3431 6.5 12 6.5Z"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                    />
+                    <path
+                        d="M7.5 17.5C7.5 15.2909 9.29086 13.5 11.5 13.5H12.5C14.7091 13.5 16.5 15.2909 16.5 17.5"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                    />
+                    <path d="M19 9.25V12.75" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                    <path d="M20.75 11H17.25" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                </svg>
+            );
+    }
+};
+
+const ChevronRight = (props) => (
+    <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" {...props}>
+        <path d="M6 3L10 8L6 13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+);
+
+QuickAddIllustration.propTypes = {
+    variant: PropTypes.string,
 };
 
 export default function BottomNav() {
+    const dispatch = useDispatch();
     const { currentUser } = useSelector((state) => state.user);
+    const { theme } = useSelector((state) => state.theme);
     const location = useLocation();
     const isAdmin = Boolean(currentUser?.isAdmin);
 
-    const navItems = [...baseItems];
-    if (currentUser) {
-        navItems.push({
-            to: '/dashboard',
-            label: 'Dashboard',
-            icon: FaUser,
-            match: (path) => path.startsWith('/dashboard'),
-        });
-    }
+    const navItems = useMemo(() => {
+        const items = [...baseDockItems];
+        if (currentUser) {
+            items.push(dashboardDockItem);
+        }
+        return items;
+    }, [currentUser]);
 
-    const dockItems = [
-        ...navItems,
-        { type: 'quick-add', label: 'Quick Add', key: 'quick-add' },
-        { type: 'theme', label: 'Theme', key: 'theme-toggle' },
-    ];
+    const dockItems = useMemo(() => [...navItems, quickAddDockItem, themeDockItem], [navItems]);
 
     const quickAddOptions = useMemo(() => {
         const options = [...BASE_QUICK_ADD_OPTIONS];
@@ -189,7 +296,7 @@ export default function BottomNav() {
             const scaleBoost = isActive ? 0.45 : 0.35;
             const scale = (isActive ? 1.2 : 1) + clamped * scaleBoost;
             const lift = (isActive ? -10 : 0) - clamped * 24;
-            const rotate = (hoverX - center) / 100; // Rotation based on mouse hover position
+            const rotate = (hoverX - center) / 100;
 
             return {
                 scale,
@@ -204,6 +311,8 @@ export default function BottomNav() {
     const handleFocus = (index) => setFocusedIndex(index);
     const handleBlur = () => setFocusedIndex(null);
 
+    const handleThemeToggle = () => dispatch(toggleTheme());
+
     return (
         <nav className="fixed bottom-6 left-1/2 z-50 flex w-full max-w-4xl -translate-x-1/2 justify-center px-4">
             <motion.ul
@@ -216,7 +325,6 @@ export default function BottomNav() {
             >
                 {dockItems.map((item, index) => {
                     const isTheme = item.type === 'theme';
-                    const Icon = item.icon;
                     const isQuickAdd = item.type === 'quick-add';
                     const isActive = !isTheme && !isQuickAdd && item.match ? item.match(location.pathname) : false;
                     let { scale, lift, proximity, rotate } = getMetrics(index, isActive);
@@ -234,9 +342,11 @@ export default function BottomNav() {
                             : proximity > 0.55 || isActive || focusedIndex === index;
 
                     const glowOpacity = Math.max(0, proximity - 0.25);
-                    const ringOpacity = Math.max(0, proximity - 0.4);
+                    const baseRingOpacity = Math.max(0, proximity - 0.4);
+                    const ringOpacity = isTheme || isQuickAdd ? Math.max(0.25, baseRingOpacity) : baseRingOpacity;
 
                     const label = item.label;
+                    const iconAlt = item.iconAlt ?? label;
 
                     return (
                         <motion.li key={item.to ?? item.key ?? label} className="relative flex flex-col items-center">
@@ -259,14 +369,38 @@ export default function BottomNav() {
                                         animate={{ opacity: glowOpacity }}
                                         transition={{ duration: 0.18 }}
                                     />
+                                    <motion.span
+                                        aria-hidden="true"
+                                        className="pointer-events-none absolute left-1/2 top-full z-0 mt-1 h-6 w-12 -translate-x-1/2 rounded-b-[28px] bg-gradient-to-t from-white/60 via-white/10 to-transparent opacity-70 dark:from-slate-200/30"
+                                        initial={false}
+                                        animate={{ opacity: Math.max(0, proximity - 0.15), scaleY: 1 + proximity * 0.25 }}
+                                        transition={{ duration: 0.2 }}
+                                    />
                                     {isTheme ? (
-                                        <div className={`flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 ${INACTIVE_CLASSES}`}>
-                                            <ThemeToggle
-                                                className="h-12 w-12 rounded-full !bg-transparent !p-0 !text-slate-600 dark:!text-slate-200"
-                                                onFocus={() => handleFocus(index)}
-                                                onBlur={handleBlur}
-                                            />
-                                        </div>
+                                        <button
+                                            type="button"
+                                            aria-label={label}
+                                            aria-pressed={theme === 'dark'}
+                                            onClick={handleThemeToggle}
+                                            onFocus={() => handleFocus(index)}
+                                            onBlur={handleBlur}
+                                            className="group relative flex flex-col items-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 focus-visible:ring-offset-4 focus-visible:ring-offset-transparent"
+                                        >
+                                            <div className={`${ICON_CONTAINER_BASE} ${theme === 'dark' ? ACTIVE_CLASSES : INACTIVE_CLASSES}`}>
+                                                <span className="pointer-events-none absolute inset-[2px] rounded-[20px] border border-white/40 bg-gradient-to-br from-white/40 via-white/10 to-transparent dark:border-white/10" />
+                                                <span className="pointer-events-none absolute inset-x-3 top-1.5 h-1/3 rounded-[18px] bg-gradient-to-b from-white/90 via-white/20 to-transparent opacity-80 dark:from-white/40" />
+                                                <span className="pointer-events-none absolute inset-x-2 bottom-1 h-1/3 rounded-b-[18px] bg-gradient-to-t from-white/20 via-transparent to-transparent opacity-60 dark:from-white/5" />
+                                                <motion.img
+                                                    src={item.iconSrc}
+                                                    alt={iconAlt}
+                                                    className="relative h-12 w-12 select-none object-contain drop-shadow-[0_10px_18px_rgba(15,23,42,0.35)]"
+                                                    initial={false}
+                                                    animate={{ rotate: theme === 'dark' ? 180 : 0 }}
+                                                    transition={{ type: 'spring', stiffness: 240, damping: 18 }}
+                                                    draggable={false}
+                                                />
+                                            </div>
+                                        </button>
                                     ) : isQuickAdd ? (
                                         <button
                                             type="button"
@@ -274,9 +408,7 @@ export default function BottomNav() {
                                             aria-label={label}
                                             aria-haspopup="menu"
                                             aria-expanded={isQuickAddOpen}
-                                            className={`group relative flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 dark:focus-visible:ring-sky-400 ${
-                                                isQuickAddOpen ? ACTIVE_CLASSES : INACTIVE_CLASSES
-                                            }`}
+                                            className={`group relative flex flex-col items-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 focus-visible:ring-offset-4 focus-visible:ring-offset-transparent ${isQuickAddOpen ? 'scale-105' : ''}`}
                                             onClick={() => setIsQuickAddOpen((open) => !open)}
                                             onFocus={() => handleFocus(index)}
                                             onBlur={(event) => {
@@ -286,31 +418,51 @@ export default function BottomNav() {
                                                 handleBlur();
                                             }}
                                         >
-                                            <FaPlus className="text-3xl" />
+                                            <div className={`${ICON_CONTAINER_BASE} ${isQuickAddOpen ? ACTIVE_CLASSES : INACTIVE_CLASSES}`}>
+                                                <span className="pointer-events-none absolute inset-[2px] rounded-[20px] border border-white/40 bg-gradient-to-br from-white/40 via-white/10 to-transparent dark:border-white/10" />
+                                                <span className="pointer-events-none absolute inset-x-3 top-1.5 h-1/3 rounded-[18px] bg-gradient-to-b from-white/90 via-white/20 to-transparent opacity-80 dark:from-white/40" />
+                                                <span className="pointer-events-none absolute inset-x-2 bottom-1 h-1/3 rounded-b-[18px] bg-gradient-to-t from-white/20 via-transparent to-transparent opacity-60 dark:from-white/5" />
+                                                <motion.img
+                                                    src={item.iconSrc}
+                                                    alt={iconAlt}
+                                                    className="relative h-12 w-12 select-none object-contain drop-shadow-[0_10px_18px_rgba(15,23,42,0.35)]"
+                                                    initial={false}
+                                                    animate={{ scale: isQuickAddOpen ? 1.08 : 1 }}
+                                                    transition={{ duration: 0.2 }}
+                                                    draggable={false}
+                                                />
+                                            </div>
                                         </button>
                                     ) : (
                                         <Link
                                             to={item.to}
                                             aria-label={label}
                                             aria-current={isActive ? 'page' : undefined}
-                                            className="group relative flex flex-col items-center"
+                                            className="group relative flex flex-col items-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/80 focus-visible:ring-offset-4 focus-visible:ring-offset-transparent"
                                             onFocus={() => handleFocus(index)}
                                             onBlur={handleBlur}
                                         >
-                                            <div
-                                                className={`flex h-14 w-14 items-center justify-center rounded-full transition-all duration-300 ${
-                                                    isActive ? ACTIVE_CLASSES : INACTIVE_CLASSES
-                                                }`}
-                                            >
-                                                {Icon ? <Icon className="text-[1.75rem]" /> : null}
+                                            <div className={`${ICON_CONTAINER_BASE} ${isActive ? ACTIVE_CLASSES : INACTIVE_CLASSES}`}>
+                                                <span className="pointer-events-none absolute inset-[2px] rounded-[20px] border border-white/40 bg-gradient-to-br from-white/40 via-white/10 to-transparent dark:border-white/10" />
+                                                <span className="pointer-events-none absolute inset-x-3 top-1.5 h-1/3 rounded-[18px] bg-gradient-to-b from-white/90 via-white/20 to-transparent opacity-80 dark:from-white/40" />
+                                                <span className="pointer-events-none absolute inset-x-2 bottom-1 h-1/3 rounded-b-[18px] bg-gradient-to-t from-white/20 via-transparent to-transparent opacity-60 dark:from-white/5" />
+                                                <motion.img
+                                                    src={item.iconSrc}
+                                                    alt={iconAlt}
+                                                    className="relative h-12 w-12 select-none object-contain drop-shadow-[0_10px_18px_rgba(15,23,42,0.35)]"
+                                                    initial={false}
+                                                    animate={{ scale: isActive ? 1.05 : 1 }}
+                                                    transition={{ duration: 0.2 }}
+                                                    draggable={false}
+                                                />
                                             </div>
                                         </Link>
                                     )}
                                     <motion.span
                                         aria-hidden="true"
-                                        className="pointer-events-none absolute inset-0 rounded-full ring-2 ring-sky-200/60 dark:ring-slate-400/40"
+                                        className="pointer-events-none absolute inset-0 rounded-[22px] ring-2 ring-sky-200/60 dark:ring-slate-400/40"
                                         initial={{ opacity: 0 }}
-                                        animate={{ opacity: isTheme ? 0 : ringOpacity }}
+                                        animate={{ opacity: isTheme ? ringOpacity : ringOpacity }}
                                         transition={{ duration: 0.2 }}
                                     />
                                     <AnimatePresence>
@@ -351,38 +503,35 @@ export default function BottomNav() {
                                                 aria-label="Quick add shortcuts"
                                             >
                                                 <motion.ul initial={false} className="space-y-2">
-                                                    {quickAddOptions.map((option) => {
-                                                        const OptionIcon = option.icon;
-                                                        return (
-                                                            <motion.li
-                                                                key={option.to}
-                                                                initial={{ opacity: 0, x: -8 }}
-                                                                animate={{ opacity: 1, x: 0 }}
-                                                                exit={{ opacity: 0, x: -6 }}
-                                                                transition={{ duration: 0.18 }}
+                                                    {quickAddOptions.map((option) => (
+                                                        <motion.li
+                                                            key={option.to}
+                                                            initial={{ opacity: 0, x: -8 }}
+                                                            animate={{ opacity: 1, x: 0 }}
+                                                            exit={{ opacity: 0, x: -6 }}
+                                                            transition={{ duration: 0.18 }}
+                                                        >
+                                                            <Link
+                                                                to={option.to}
+                                                                className="group flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/80 px-3 py-3 text-left shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/70 hover:border-cyan-200 hover:bg-white dark:border-slate-700/70 dark:bg-slate-900/70 dark:hover:border-sky-500/40 dark:hover:bg-slate-900"
+                                                                role="menuitem"
+                                                                onClick={() => setIsQuickAddOpen(false)}
                                                             >
-                                                                <Link
-                                                                    to={option.to}
-                                                                    className="group flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/80 px-3 py-3 text-left shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/70 hover:border-cyan-200 hover:bg-white dark:border-slate-700/70 dark:bg-slate-900/70 dark:hover:border-sky-500/40 dark:hover:bg-slate-900"
-                                                                    role="menuitem"
-                                                                    onClick={() => setIsQuickAddOpen(false)}
-                                                                >
-                                                                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-400/20 via-sky-500/20 to-blue-500/20 text-sky-500 shadow-inner shadow-white/40 dark:text-sky-300">
-                                                                        {OptionIcon ? <OptionIcon className="text-lg" /> : null}
+                                                                <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-400/20 via-sky-500/20 to-blue-500/20 text-sky-500 shadow-inner shadow-white/40 dark:text-sky-300">
+                                                                    <QuickAddIllustration variant={option.illustration} />
+                                                                </span>
+                                                                <span className="flex-1">
+                                                                    <span className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
+                                                                        {option.label}
                                                                     </span>
-                                                                    <span className="flex-1">
-                                                                        <span className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
-                                                                            {option.label}
-                                                                        </span>
-                                                                        <span className="mt-0.5 block text-xs text-slate-500 transition group-hover:text-slate-700 dark:text-slate-400 dark:group-hover:text-slate-200">
-                                                                            {option.description}
-                                                                        </span>
+                                                                    <span className="mt-0.5 block text-xs text-slate-500 transition group-hover:text-slate-700 dark:text-slate-400 dark:group-hover:text-slate-200">
+                                                                        {option.description}
                                                                     </span>
-                                                                    <FaChevronRight className="text-slate-300 transition group-hover:text-slate-500 dark:text-slate-600 dark:group-hover:text-slate-300" />
-                                                                </Link>
-                                                            </motion.li>
-                                                        );
-                                                    })}
+                                                                </span>
+                                                                <ChevronRight className="h-3.5 w-3.5 text-slate-300 transition group-hover:text-slate-500 dark:text-slate-600 dark:group-hover:text-slate-300" />
+                                                            </Link>
+                                                        </motion.li>
+                                                    ))}
                                                 </motion.ul>
                                             </motion.div>
                                         ) : null}

--- a/client/src/data/dockItems.js
+++ b/client/src/data/dockItems.js
@@ -1,0 +1,95 @@
+import homeIcon from '../assets/dock/home.svg';
+import tutorialsIcon from '../assets/dock/tutorials.svg';
+import quizzesIcon from '../assets/dock/quizzes.svg';
+import toolsIcon from '../assets/dock/tools.svg';
+import problemsIcon from '../assets/dock/problems.svg';
+import visualizerIcon from '../assets/dock/visualizer.svg';
+import dashboardIcon from '../assets/dock/dashboard.svg';
+import quickAddIcon from '../assets/dock/quick-add.svg';
+import themeIcon from '../assets/dock/theme.svg';
+
+export const baseDockItems = [
+    {
+        key: 'home',
+        to: '/',
+        label: 'Home',
+        iconSrc: homeIcon,
+        iconAlt: 'Home dock icon',
+        match: (path) => path === '/',
+    },
+    {
+        key: 'tutorials',
+        to: '/tutorials',
+        label: 'Tutorials',
+        iconSrc: tutorialsIcon,
+        iconAlt: 'Tutorials dock icon',
+        match: (path) => path.startsWith('/tutorials'),
+    },
+    {
+        key: 'quizzes',
+        to: '/quizzes',
+        label: 'Quizzes',
+        iconSrc: quizzesIcon,
+        iconAlt: 'Quizzes dock icon',
+        match: (path) => path.startsWith('/quizzes'),
+    },
+    {
+        key: 'tools',
+        to: '/tools',
+        label: 'Tools',
+        iconSrc: toolsIcon,
+        iconAlt: 'Tools dock icon',
+        match: (path) => path.startsWith('/tools'),
+    },
+    {
+        key: 'problems',
+        to: '/problems',
+        label: 'Problems',
+        iconSrc: problemsIcon,
+        iconAlt: 'Problems dock icon',
+        match: (path) => path.startsWith('/problems'),
+    },
+    {
+        key: 'visualizer',
+        to: '/visualizer',
+        label: 'Code Visualizer',
+        iconSrc: visualizerIcon,
+        iconAlt: 'Visualizer dock icon',
+        match: (path) => path.startsWith('/visualizer'),
+    },
+];
+
+export const dashboardDockItem = {
+    key: 'dashboard',
+    to: '/dashboard',
+    label: 'Dashboard',
+    iconSrc: dashboardIcon,
+    iconAlt: 'Dashboard dock icon',
+    match: (path) => path.startsWith('/dashboard'),
+    requiresAuth: true,
+};
+
+export const quickAddDockItem = {
+    key: 'quick-add',
+    type: 'quick-add',
+    label: 'Quick Add',
+    iconSrc: quickAddIcon,
+    iconAlt: 'Open quick add shortcuts',
+};
+
+export const themeDockItem = {
+    key: 'theme',
+    type: 'theme',
+    label: 'Theme',
+    iconSrc: themeIcon,
+    iconAlt: 'Toggle theme',
+};
+
+export const baseDockSequence = [...baseDockItems, quickAddDockItem, themeDockItem];
+
+export const dockSequenceWithDashboard = [
+    ...baseDockItems,
+    dashboardDockItem,
+    quickAddDockItem,
+    themeDockItem,
+];


### PR DESCRIPTION
## Summary
- add a dedicated dock asset set with macOS-inspired squircle SVG icons for each navigation entry
- extract dock item configuration into a reusable data module and update the dock to consume it
- refresh BottomNav with glassmorphism styling, image-based icons, and inline quick add illustrations that match the new dock visuals

## Testing
- npm run lint *(fails: existing lint violations across unrelated components)*

------
https://chatgpt.com/codex/tasks/task_b_68da9e61e13c8326858b9e10d2092768