### PR TITLE
Revamp PostPage UI and reading experience

### DIFF
--- a/client/src/pages/PostPage.jsx
+++ b/client/src/pages/PostPage.jsx
@@ -1,5 +1,5 @@
 // client/src/pages/PostPage.jsx
-import { Button, Alert } from 'flowbite-react';
+import { Button, Alert, Tooltip } from 'flowbite-react';
 import { Link, useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
@@ -7,6 +7,8 @@ import { useEffect, useState, useMemo } from 'react';
 import hljs from 'highlight.js';
 import ImageViewer from 'react-simple-image-viewer';
 import { Helmet } from 'react-helmet-async';
+import { FaClock, FaBookOpen, FaCalendarAlt } from 'react-icons/fa';
+import { HiOutlineSparkles } from 'react-icons/hi';
 
 // --- Component Imports ---
 import CommentSection from '../components/CommentSection';
@@ -45,16 +47,31 @@ const fetchRelatedPosts = async (category) => {
 
 // --- Skeleton Component (Unchanged) ---
 const PostPageSkeleton = () => (
-    <main className='p-3 flex flex-col max-w-6xl mx-auto min-h-screen animate-pulse'>
-        <div className='h-10 bg-gray-300 dark:bg-gray-600 rounded-md mt-10 p-3 max-w-2xl mx-auto w-full'></div>
-        <div className='h-6 w-24 bg-gray-300 dark:bg-gray-600 rounded-full self-center mt-5'></div>
-        <div className='mt-10 p-3 max-h-[600px] w-full h-96 bg-gray-300 dark:bg-gray-600 rounded-lg'></div>
-        <div className='p-3 max-w-2xl mx-auto w-full mt-5'>
-            <div className='h-4 bg-gray-300 dark:bg-gray-600 rounded-full w-full mb-4'></div>
-            <div className='h-4 bg-gray-300 dark:bg-gray-600 rounded-full w-full mb-4'></div>
-            <div className='h-4 bg-gray-300 dark:bg-gray-600 rounded-full w-3/4'></div>
+    <div className='min-h-screen bg-gradient-to-b from-slate-100 via-white to-slate-100 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950'>
+        <div className='relative isolate overflow-hidden bg-slate-900 text-white'>
+            <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.2),_transparent_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.3),_transparent_55%)]' />
+            <div className='mx-auto flex max-w-4xl flex-col gap-6 px-6 py-24 text-center'>
+                <div className='mx-auto h-7 w-24 rounded-full bg-white/30' />
+                <div className='mx-auto h-14 w-3/4 rounded-2xl bg-white/30' />
+                <div className='mx-auto flex w-full max-w-xl items-center justify-center gap-4'>
+                    <div className='h-4 w-24 rounded-full bg-white/30' />
+                    <div className='h-4 w-24 rounded-full bg-white/30' />
+                    <div className='h-4 w-24 rounded-full bg-white/30' />
+                </div>
+            </div>
         </div>
-    </main>
+        <main className='mx-auto flex max-w-6xl flex-col gap-10 px-4 py-10 lg:flex-row lg:px-10'>
+            <div className='flex-1 space-y-6'>
+                <div className='h-96 w-full rounded-3xl bg-white shadow-xl shadow-slate-200/60 ring-1 ring-slate-200/70 dark:bg-slate-900/80 dark:shadow-slate-900/50 dark:ring-white/5' />
+                <div className='space-y-4 rounded-3xl bg-white p-8 shadow-xl shadow-slate-200/60 ring-1 ring-slate-200/70 dark:bg-slate-900/80 dark:shadow-slate-900/50 dark:ring-white/5'>
+                    {[...Array(5).keys()].map((key) => (
+                        <div key={key} className='h-4 w-full rounded-full bg-slate-200 dark:bg-slate-700' />
+                    ))}
+                </div>
+            </div>
+            <aside className='h-96 w-full rounded-3xl bg-white shadow-xl shadow-slate-200/60 ring-1 ring-slate-200/70 dark:bg-slate-900/80 dark:shadow-slate-900/50 dark:ring-white/5 lg:w-80' />
+        </main>
+    </div>
 );
 
 // --- Helper functions (Unchanged) ---
@@ -66,6 +83,15 @@ const getTextFromNode = (node) => {
     if (node.type === 'text') return node.data;
     if (node.type !== 'tag' || !node.children) return '';
     return node.children.map(getTextFromNode).join('');
+};
+
+const formatCategory = (category) => {
+    if (!category) return 'Uncategorized';
+    return category
+        .split(/[-_\s]+/)
+        .filter(Boolean)
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join(' ');
 };
 
 export default function PostPage() {
@@ -232,16 +258,62 @@ export default function PostPage() {
         if (!htmlContent) return '';
         const tempDiv = document.createElement('div');
         tempDiv.innerHTML = htmlContent;
-        return tempDiv.textContent.trim().slice(0, 155) + '...';
+        return `${tempDiv.textContent.trim().slice(0, 155)}...`;
     };
+
+    const metaDescription = useMemo(() => createMetaDescription(post?.content), [post?.content]);
+
+    const readingStats = useMemo(() => {
+        if (!sanitizedContent) return { wordCount: 0, readingMinutes: 0 };
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = sanitizedContent;
+        const text = tempDiv.textContent || '';
+        const words = text.trim().split(/\s+/).filter(Boolean);
+        const wordCount = words.length;
+        const readingMinutes = wordCount ? Math.max(1, Math.ceil(wordCount / 200)) : 0;
+        return { wordCount, readingMinutes };
+    }, [sanitizedContent]);
+
+    const formattedPublishDate = useMemo(() => {
+        if (!post?.createdAt) return '';
+        try {
+            return new Date(post.createdAt).toLocaleDateString('en-IN', {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+            });
+        } catch (error) {
+            return '';
+        }
+    }, [post?.createdAt]);
+
+    const heroImage = useMemo(() => {
+        if (!post) return null;
+        if (post.mediaType === 'video') return post.image || null;
+        return post.mediaUrl || post.image || null;
+    }, [post]);
+
+    const heroBackgroundStyle = useMemo(() => {
+        if (!heroImage) return {};
+        return {
+            backgroundImage: `linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.35)), url(${heroImage})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+        };
+    }, [heroImage]);
+
+    const categoryQuery = useMemo(() => {
+        if (!post?.category) return 'all';
+        return encodeURIComponent(post.category);
+    }, [post?.category]);
 
     return (
         <>
             <Helmet>
                 <title>{post.title}</title>
-                <meta name="description" content={createMetaDescription(post.content)} />
+                <meta name="description" content={metaDescription} />
                 <meta property="og:title" content={post.title} />
-                <meta property="og:description" content={createMetaDescription(post.content)} />
+                <meta property="og:description" content={metaDescription} />
                 <meta property="og:image" content={post.mediaUrl || post.image} />
                 <meta property="og:url" content={window.location.href} />
                 <meta property="og:type" content="article" />
@@ -254,69 +326,165 @@ export default function PostPage() {
             />
 
             <ReadingProgressBar />
-            <main className='p-3 flex flex-col max-w-6xl mx-auto min-h-screen'>
-                <h1
-                    className='text-3xl mt-10 p-3 text-center font-serif max-w-2xl mx-auto lg:text-4xl'
-                    style={sharedContentStyle}
+            <div className='min-h-screen bg-gradient-to-b from-slate-100 via-white to-slate-100 pb-16 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950'>
+                <section
+                    className='relative isolate overflow-hidden bg-slate-900 text-white'
+                    style={heroBackgroundStyle}
                 >
-                    {post.title}
-                </h1>
-                <Link to={`/search?category=${post.category}`} className='self-center mt-5'>
-                    <Button color='gray' pill size='xs'>{post.category}</Button>
-                </Link>
-                <div
-                    className='mt-10 p-3 max-h-[600px] w-full flex justify-center'
-                    style={sharedContentStyle}
-                >
-                    {post.mediaType === 'video' ? <video src={post.mediaUrl} controls className='w-full object-contain rounded-lg shadow-lg' /> : <img src={post.mediaUrl || post.image} alt={post.title} className='w-full object-contain rounded-lg shadow-lg' />}
-                </div>
-                <div
-                    className='flex justify-between p-3 border-b border-slate-500 mx-auto w-full max-w-2xl text-xs'
-                    style={sharedContentStyle}
-                >
-                    <span>{new Date(post.createdAt).toLocaleDateString("en-IN", { day: 'numeric', month: 'long', year: 'numeric' })}</span>
-                    <span className='italic'>{post.content ? `${Math.ceil(post.content.split(' ').length / 200)} min read` : '0 min read'}</span>
-                </div>
-
-                <div
-                    className='max-w-2xl mx-auto w-full'
-                    style={sharedContentStyle}
-                >
-                    <TableOfContents headings={headings} />
-                </div>
-
-                <InteractiveReadingSurface
-                    content={sanitizedContent}
-                    parserOptions={parserOptions}
-                    contentStyles={contentStyles}
-                    contentMaxWidth={contentMaxWidth}
-                    surfaceClass={surfaceClass}
-                    className='p-3 max-w-2xl mx-auto w-full post-content tiptap reading-surface transition-all duration-300'
-                    chapterId={post._id}
-                />
-
-                <div
-                    className='max-w-2xl mx-auto w-full px-3 my-8 flex justify-between items-center'
-                    style={sharedContentStyle}
-                >
-                    <ClapButton post={post} />
-                    <SocialShare post={post} />
-                </div>
-
-                <div
-                    className='max-w-2xl mx-auto w-full'
-                    style={sharedContentStyle}
-                >
-                    <CommentSection postId={post._id} />
-                </div>
-
-                <div className='flex flex-col justify-center items-center mb-5'>
-                    <h1 className='text-xl mt-5'>Related articles</h1>
-                    <div className='flex flex-wrap gap-5 mt-5 justify-center'>
-                        {relatedPosts && relatedPosts.filter(p => p._id !== post._id).map((p) => <PostCard key={p._id} post={p} />)}
+                    <div className='absolute inset-0 bg-slate-900/75 backdrop-blur-sm dark:bg-slate-950/80' />
+                    <div className='relative mx-auto flex max-w-4xl flex-col gap-8 px-6 py-24 text-center sm:py-28 lg:px-0'>
+                        <div className='inline-flex items-center justify-center gap-2 self-center rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-slate-100 backdrop-blur'>
+                            <HiOutlineSparkles className='h-4 w-4 text-amber-300' aria-hidden />
+                            Featured Insight
+                        </div>
+                        <Link to={`/search?category=${categoryQuery}`} className='inline-flex items-center justify-center self-center'>
+                            <span className='inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-1 text-xs font-medium uppercase tracking-wide text-slate-100 ring-1 ring-white/30 backdrop-blur-sm transition hover:bg-white/30'>
+                                {formatCategory(post.category)}
+                            </span>
+                        </Link>
+                        <h1 className='text-balance text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl'>
+                            {post.title}
+                        </h1>
+                        {metaDescription && (
+                            <p className='mx-auto max-w-2xl text-base text-slate-200 sm:text-lg'>
+                                {metaDescription}
+                            </p>
+                        )}
+                        <div className='mx-auto flex flex-wrap items-center justify-center gap-6 text-sm text-slate-200'>
+                            {formattedPublishDate && (
+                                <span className='inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 ring-1 ring-white/15'>
+                                    <FaCalendarAlt className='h-4 w-4' aria-hidden />
+                                    {formattedPublishDate}
+                                </span>
+                            )}
+                            {readingStats.readingMinutes > 0 && (
+                                <span className='inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 ring-1 ring-white/15'>
+                                    <FaClock className='h-4 w-4' aria-hidden />
+                                    {readingStats.readingMinutes} min read
+                                </span>
+                            )}
+                            {readingStats.wordCount > 0 && (
+                                <span className='inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 ring-1 ring-white/15'>
+                                    <FaBookOpen className='h-4 w-4' aria-hidden />
+                                    {readingStats.wordCount.toLocaleString()} words
+                                </span>
+                            )}
+                        </div>
                     </div>
-                </div>
-            </main>
+                </section>
+
+                <main className='mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 pt-10 lg:flex-row lg:px-8'>
+                    <article className='flex-1 space-y-10'>
+                        {(post.mediaUrl || post.image) && (
+                            <div className='overflow-hidden rounded-3xl border border-slate-200/60 bg-white shadow-xl shadow-slate-200/70 transition duration-500 hover:-translate-y-1 hover:shadow-2xl dark:border-white/5 dark:bg-slate-900/70 dark:shadow-slate-900/60'>
+                                {post.mediaType === 'video' ? (
+                                    <video
+                                        src={post.mediaUrl}
+                                        controls
+                                        className='h-full w-full rounded-3xl object-cover'
+                                        poster={post.image || undefined}
+                                    />
+                                ) : (
+                                    <img
+                                        src={post.mediaUrl || post.image}
+                                        alt={post.title}
+                                        className='h-full w-full object-cover'
+                                        loading='lazy'
+                                    />
+                                )}
+                            </div>
+                        )}
+
+                        <div
+                            className='overflow-hidden rounded-3xl border border-slate-200/70 bg-white shadow-xl shadow-slate-200/70 dark:border-white/5 dark:bg-slate-900/70 dark:shadow-slate-900/60'
+                            style={sharedContentStyle}
+                        >
+                            <InteractiveReadingSurface
+                                content={sanitizedContent}
+                                parserOptions={parserOptions}
+                                contentStyles={contentStyles}
+                                contentMaxWidth={contentMaxWidth}
+                                surfaceClass={surfaceClass}
+                                className='post-content tiptap reading-surface w-full space-y-6 px-6 py-8 text-left text-slate-700 transition-all duration-300 dark:text-slate-200 sm:px-10 sm:py-12'
+                                chapterId={post._id}
+                            />
+                        </div>
+
+                        <div className='flex flex-col gap-6 rounded-3xl border border-slate-200/70 bg-white p-6 shadow-xl shadow-slate-200/70 dark:border-white/5 dark:bg-slate-900/70 dark:shadow-slate-900/60 sm:flex-row sm:items-center sm:justify-between'>
+                            <ClapButton post={post} />
+                            <div className='flex items-center gap-3'>
+                                <Tooltip content='Share this insight'>
+                                    <span>
+                                        <SocialShare post={post} />
+                                    </span>
+                                </Tooltip>
+                            </div>
+                        </div>
+
+                        <div className='overflow-hidden rounded-3xl border border-slate-200/70 bg-white p-6 shadow-xl shadow-slate-200/70 dark:border-white/5 dark:bg-slate-900/70 dark:shadow-slate-900/60'>
+                            <CommentSection postId={post._id} />
+                        </div>
+
+                        {relatedPosts && relatedPosts.filter(p => p._id !== post._id).length > 0 && (
+                            <section className='space-y-6 rounded-3xl border border-slate-200/70 bg-white p-6 shadow-xl shadow-slate-200/70 dark:border-white/5 dark:bg-slate-900/70 dark:shadow-slate-900/60'>
+                                <div className='flex items-center justify-between'>
+                                    <h2 className='text-lg font-semibold text-slate-800 dark:text-slate-100'>Related articles</h2>
+                                    <span className='text-xs uppercase tracking-wide text-slate-400'>Curated for you</span>
+                                </div>
+                                <div className='grid gap-5 md:grid-cols-2'>
+                                    {relatedPosts
+                                        .filter(p => p._id !== post._id)
+                                        .map((p) => (
+                                            <PostCard key={p._id} post={p} />
+                                        ))}
+                                </div>
+                            </section>
+                        )}
+                    </article>
+
+                    <aside className='w-full space-y-8 lg:w-80 lg:pt-6'>
+                        <div className='sticky top-28 flex flex-col gap-8'>
+                            <div className='overflow-hidden rounded-3xl border border-slate-200/70 bg-white p-6 shadow-xl shadow-slate-200/70 dark:border-white/5 dark:bg-slate-900/70 dark:shadow-slate-900/60'>
+                                <h2 className='text-base font-semibold text-slate-800 dark:text-slate-100'>On this page</h2>
+                                <p className='mt-2 text-sm text-slate-500 dark:text-slate-400'>Navigate through the key sections of this story.</p>
+                                <div className='mt-4 max-h-[60vh] overflow-y-auto pr-1 text-sm'>
+                                    <TableOfContents headings={headings} />
+                                </div>
+                            </div>
+
+                            <div className='rounded-3xl border border-slate-200/70 bg-white p-6 shadow-xl shadow-slate-200/70 dark:border-white/5 dark:bg-slate-900/70 dark:shadow-slate-900/60'>
+                                <h3 className='text-base font-semibold text-slate-800 dark:text-slate-100'>Reading insights</h3>
+                                <ul className='mt-4 space-y-3 text-sm text-slate-600 dark:text-slate-300'>
+                                    {formattedPublishDate && (
+                                        <li className='flex items-center gap-3 rounded-2xl bg-slate-100/60 px-3 py-2 dark:bg-slate-800/70'>
+                                            <FaCalendarAlt className='h-4 w-4 text-slate-500 dark:text-slate-400' aria-hidden />
+                                            Published on {formattedPublishDate}
+                                        </li>
+                                    )}
+                                    {readingStats.readingMinutes > 0 && (
+                                        <li className='flex items-center gap-3 rounded-2xl bg-slate-100/60 px-3 py-2 dark:bg-slate-800/70'>
+                                            <FaClock className='h-4 w-4 text-slate-500 dark:text-slate-400' aria-hidden />
+                                            {readingStats.readingMinutes} minute read
+                                        </li>
+                                    )}
+                                    {readingStats.wordCount > 0 && (
+                                        <li className='flex items-center gap-3 rounded-2xl bg-slate-100/60 px-3 py-2 dark:bg-slate-800/70'>
+                                            <FaBookOpen className='h-4 w-4 text-slate-500 dark:text-slate-400' aria-hidden />
+                                            {readingStats.wordCount.toLocaleString()} words to explore
+                                        </li>
+                                    )}
+                                </ul>
+                                <div className='mt-6 rounded-2xl bg-gradient-to-r from-emerald-500 via-sky-500 to-indigo-500 p-[1px]'>
+                                    <div className='rounded-2xl bg-white p-5 text-center dark:bg-slate-950'>
+                                        <p className='text-sm font-medium text-slate-700 dark:text-slate-200'>Adjust the reading experience to match your focus preference.</p>
+                                        <p className='mt-2 text-xs text-slate-500 dark:text-slate-400'>Use the floating control center to tweak focus mode, guide lines and contrast.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </aside>
+                </main>
+            </div>
 
             {isViewerOpen && (
                 <ImageViewer


### PR DESCRIPTION
## Summary
- redesign the PostPage hero, reading surface, and skeleton loader for a more immersive presentation
- surface reading insights, sharing affordances, and curated related posts alongside the article content
- introduce a sticky sidebar with table of contents navigation and reading tips to guide the experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db4ff011b88326a47cd9547d9f328a