### PR TITLE
Fix hook order in PostPage to prevent hook mismatch error

### DIFF
--- a/client/src/pages/PostPage.jsx
+++ b/client/src/pages/PostPage.jsx
@@ -216,44 +216,6 @@ export default function PostPage() {
         };
     }, [readingSettings.focusMode, readingSettings.readingGuide, readingSettings.highContrast]);
 
-    if (isLoadingPost) return <PostPageSkeleton />;
-    if (postError) return (
-        <div className='flex justify-center items-center min-h-screen'>
-            <Alert color='failure' className='text-xl'>Error: {postError.message}</Alert>
-        </div>
-    );
-    if (!post) return null;
-
-    const parserOptions = {
-        replace: domNode => {
-            if (domNode.type === 'tag' && (domNode.name === 'h2' || domNode.name === 'h3')) {
-                const textContent = getTextFromNode(domNode);
-                const id = generateSlug(textContent);
-                if (id) domNode.attribs.id = id;
-                return;
-            }
-            if (domNode.type === 'tag' && domNode.name === 'img') {
-                const src = domNode.attribs.src;
-                const index = imagesInPost.indexOf(src);
-                if (index > -1) {
-                    return (
-                        <img
-                            {...domNode.attribs}
-                            onClick={() => openImageViewer(index)}
-                            style={{ cursor: 'pointer' }}
-                            loading="lazy"
-                        />
-                    );
-                }
-            }
-            // NEW: Render the CodeEditor component
-            if (domNode.type === 'tag' && domNode.name === 'div' && domNode.attribs['data-snippet-id']) {
-                const snippetId = domNode.attribs['data-snippet-id'];
-                return <CodeEditor snippetId={snippetId} />;
-            }
-        }
-    };
-
     const createMetaDescription = (htmlContent) => {
         if (!htmlContent) return '';
         const tempDiv = document.createElement('div');
@@ -306,6 +268,44 @@ export default function PostPage() {
         if (!post?.category) return 'all';
         return encodeURIComponent(post.category);
     }, [post?.category]);
+
+    if (isLoadingPost) return <PostPageSkeleton />;
+    if (postError) return (
+        <div className='flex justify-center items-center min-h-screen'>
+            <Alert color='failure' className='text-xl'>Error: {postError.message}</Alert>
+        </div>
+    );
+    if (!post) return null;
+
+    const parserOptions = {
+        replace: domNode => {
+            if (domNode.type === 'tag' && (domNode.name === 'h2' || domNode.name === 'h3')) {
+                const textContent = getTextFromNode(domNode);
+                const id = generateSlug(textContent);
+                if (id) domNode.attribs.id = id;
+                return;
+            }
+            if (domNode.type === 'tag' && domNode.name === 'img') {
+                const src = domNode.attribs.src;
+                const index = imagesInPost.indexOf(src);
+                if (index > -1) {
+                    return (
+                        <img
+                            {...domNode.attribs}
+                            onClick={() => openImageViewer(index)}
+                            style={{ cursor: 'pointer' }}
+                            loading="lazy"
+                        />
+                    );
+                }
+            }
+            // NEW: Render the CodeEditor component
+            if (domNode.type === 'tag' && domNode.name === 'div' && domNode.attribs['data-snippet-id']) {
+                const snippetId = domNode.attribs['data-snippet-id'];
+                return <CodeEditor snippetId={snippetId} />;
+            }
+        }
+    };
 
     return (
         <>


### PR DESCRIPTION
## Summary
- move memoized calculations for metadata, reading stats, and hero assets ahead of conditional returns in PostPage
- keep the html-react-parser options unchanged while ensuring hook execution order remains stable

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68db5252de088326b6ac85d9b1f89ef1