### PR TITLE
Add logout confirmation modals

### DIFF
--- a/client/src/components/DashProfile.jsx
+++ b/client/src/components/DashProfile.jsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 // Import our advanced custom hook and modal component
 import { useCloudinaryUpload } from '../hooks/useCloudinaryUpload';
 import DeleteConfirmationModal from './DeleteConfirmationModal';
+import LogoutConfirmationModal from './LogoutConfirmationModal';
 
 // Import Redux actions
 import {
@@ -32,6 +33,8 @@ export default function DashProfile() {
   const [updateUserSuccess, setUpdateUserSuccess] = useState(null);
   const [updateUserError, setUpdateUserError] = useState(null);
   const [showModal, setShowModal] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
   const filePickerRef = useRef();
 
   // Use our custom hook for all upload logic
@@ -125,6 +128,7 @@ export default function DashProfile() {
 
   // Handle user sign-out
   const handleSignout = async () => {
+    setIsSigningOut(true);
     try {
       const res = await fetch('/api/user/signout', { method: 'POST' });
       const data = await res.json();
@@ -135,6 +139,9 @@ export default function DashProfile() {
       }
     } catch (error) {
       console.log(error.message);
+    } finally {
+      setIsSigningOut(false);
+      setShowLogoutModal(false);
     }
   };
 
@@ -205,7 +212,20 @@ export default function DashProfile() {
         </form>
         <div className='text-red-500 flex justify-between mt-5'>
           <span onClick={() => setShowModal(true)} className='cursor-pointer'>Delete Account</span>
-          <span onClick={handleSignout} className='cursor-pointer'>Sign Out</span>
+          <span
+              onClick={() => setShowLogoutModal(true)}
+              className='cursor-pointer'
+              role='button'
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setShowLogoutModal(true);
+                }
+              }}
+          >
+            Sign Out
+          </span>
         </div>
 
         {updateUserSuccess && <Alert color='success' className='mt-5'>{updateUserSuccess}</Alert>}
@@ -216,6 +236,12 @@ export default function DashProfile() {
             show={showModal}
             onClose={() => setShowModal(false)}
             onConfirm={handleDeleteUser}
+        />
+        <LogoutConfirmationModal
+            show={showLogoutModal}
+            onClose={() => !isSigningOut && setShowLogoutModal(false)}
+            onConfirm={handleSignout}
+            processing={isSigningOut}
         />
       </div>
   );

--- a/client/src/components/DashSidebar.jsx
+++ b/client/src/components/DashSidebar.jsx
@@ -10,10 +10,11 @@ import {
   HiPuzzle, // NEW: Import puzzle icon for quizzes
   HiCollection,
 } from 'react-icons/hi';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { signoutSuccess } from '../redux/user/userSlice';
+import LogoutConfirmationModal from './LogoutConfirmationModal';
 
 // Define sidebar links in a configuration array
 const sidebarLinks = [
@@ -32,6 +33,8 @@ export default function DashSidebar() {
   const dispatch = useDispatch();
   const { currentUser } = useSelector((state) => state.user);
   const [tab, setTab] = useState('');
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(location.search);
@@ -41,14 +44,18 @@ export default function DashSidebar() {
     }
   }, [location.search]);
 
-  const handleSignout = useCallback(async () => {
+  const handleSignout = async () => {
+    setIsSigningOut(true);
     try {
       await fetch('/api/user/signout', { method: 'POST' });
       dispatch(signoutSuccess());
     } catch (error) {
       console.log(error.message);
+    } finally {
+      setIsSigningOut(false);
+      setShowLogoutModal(false);
     }
-  }, [dispatch]);
+  };
 
   return (
       <Sidebar className='w-full md:w-56'>
@@ -86,12 +93,18 @@ export default function DashSidebar() {
             <Sidebar.Item
                 icon={HiArrowSmRight}
                 className='cursor-pointer'
-                onClick={handleSignout}
+                onClick={() => setShowLogoutModal(true)}
             >
               Sign Out
             </Sidebar.Item>
           </Sidebar.ItemGroup>
         </Sidebar.Items>
+        <LogoutConfirmationModal
+            show={showLogoutModal}
+            onClose={() => !isSigningOut && setShowLogoutModal(false)}
+            onConfirm={handleSignout}
+            processing={isSigningOut}
+        />
       </Sidebar>
   );
 }

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,5 +1,5 @@
 // client/src/components/Header.jsx
-import { Avatar, Button, Navbar, TextInput, Tooltip, Modal } from 'flowbite-react';
+import { Avatar, Button, Navbar, Tooltip } from 'flowbite-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { AiOutlineSearch } from 'react-icons/ai';
 import { useSelector, useDispatch } from 'react-redux';
@@ -9,6 +9,7 @@ import { useEffect, useState, useRef } from 'react';
 import { signoutSuccess } from '../redux/user/userSlice';
 import CommandMenu from './CommandMenu';
 import ControlCenter from './ControlCenter.jsx';
+import LogoutConfirmationModal from './LogoutConfirmationModal';
 
 // --- Reusable Components ---
 
@@ -59,6 +60,8 @@ export default function Header() {
   const [isCommandMenuOpen, setIsCommandMenuOpen] = useState(false);
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
   const { scrollY } = useScroll();
   const headerRef = useRef(null);
 
@@ -95,12 +98,21 @@ export default function Header() {
   }, []);
 
   const handleSignout = async () => {
+    setIsSigningOut(true);
     try {
       await fetch('/api/user/signout', { method: 'POST' });
       dispatch(signoutSuccess());
     } catch (error) {
       console.log(error.message);
+    } finally {
+      setIsSigningOut(false);
+      setIsLogoutModalOpen(false);
     }
+  };
+
+  const confirmSignout = () => {
+    setIsDropdownOpen(false);
+    setIsLogoutModalOpen(true);
   };
 
   const navContainerVariants = {
@@ -284,7 +296,15 @@ export default function Header() {
                               <hr className="dark:border-gray-600" />
                               <div
                                   className="block px-space-lg py-space-sm text-sm text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900 cursor-pointer"
-                                  onClick={handleSignout}
+                                  onClick={confirmSignout}
+                                  role='button'
+                                  tabIndex={0}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault();
+                                      confirmSignout();
+                                    }
+                                  }}
                               >
                                 Sign out
                               </div>
@@ -312,6 +332,12 @@ export default function Header() {
           </div>
         </motion.header>
         <CommandMenu isOpen={isCommandMenuOpen} onClose={() => setIsCommandMenuOpen(false)} />
+        <LogoutConfirmationModal
+            show={isLogoutModalOpen}
+            onClose={() => setIsLogoutModalOpen(false)}
+            onConfirm={handleSignout}
+            processing={isSigningOut}
+        />
       </>
   );
 }

--- a/client/src/components/LogoutConfirmationModal.jsx
+++ b/client/src/components/LogoutConfirmationModal.jsx
@@ -1,0 +1,25 @@
+// client/src/components/LogoutConfirmationModal.jsx
+import { Modal, Button } from 'flowbite-react';
+
+export default function LogoutConfirmationModal({ show, onClose, onConfirm, processing = false }) {
+  return (
+      <Modal show={show} onClose={processing ? () => {} : onClose} popup size='md'>
+        <Modal.Header />
+        <Modal.Body>
+          <div className='text-center'>
+            <h3 className='mb-5 text-lg font-normal text-gray-500 dark:text-gray-400'>
+              Are you sure you want to sign out?
+            </h3>
+            <div className='flex justify-center gap-4'>
+              <Button color='failure' onClick={onConfirm} isProcessing={processing} disabled={processing}>
+                Yes, sign out
+              </Button>
+              <Button color='gray' onClick={onClose} disabled={processing}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable logout confirmation modal based on Flowbite to guard sign-out actions
- update the header, profile dashboard, and sidebar to open the confirmation modal before posting the sign-out request

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dbf085732c8326a3c504a6455d5283