### PR TITLE
Add Elasticsearch-powered global search experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ ScientistShieldOne is a MERN-stack application for sharing knowledge and practic
     - `MONGO_URI` *(optional)* – MongoDB connection string (defaults to `mongodb://0.0.0.0:27017/myappp`).
     - `PORT` *(optional)* – port for the Express server (defaults to `3000`).
     - `CORS_ORIGIN` *(optional)* – allowed origin for CORS (defaults to `http://localhost:5173`).
+    - `ELASTICSEARCH_NODE` *(optional)* – URL of your Elasticsearch node (e.g., `http://localhost:9200`).
+    - `ELASTICSEARCH_USERNAME`/`ELASTICSEARCH_PASSWORD` *(optional)* – basic auth credentials for Elasticsearch.
+    - `ELASTICSEARCH_API_KEY` *(optional)* – API key for Elasticsearch (takes precedence over username/password when provided).
+    - `ELASTICSEARCH_INDEX_PREFIX` *(optional)* – prefix for Elasticsearch indices (defaults to `scientistshield`).
 
 ## Installation & Usage
 1. Clone the repository and navigate into it.

--- a/api/controllers/post.controller.js
+++ b/api/controllers/post.controller.js
@@ -1,6 +1,7 @@
 import Post from '../models/post.model.js';
 import { errorHandler } from '../utils/error.js';
 import { generateSlug } from '../utils/slug.js';
+import { indexSearchDocument, removeSearchDocument } from '../services/search.service.js';
 
 // --- CREATE, DELETEPOST, UPDATEPOST functions are here ---
 // (Your existing code for these functions remains unchanged)
@@ -20,6 +21,7 @@ export const create = async (req, res, next) => {
   });
   try {
     const savedPost = await newPost.save();
+    await indexSearchDocument('post', savedPost);
     res.status(201).json(savedPost);
   } catch (error) {
     next(error);
@@ -93,6 +95,7 @@ export const deletepost = async (req, res, next) => {
   }
   try {
     await Post.findByIdAndDelete(req.params.postId);
+    await removeSearchDocument('post', req.params.postId);
     res.status(200).json('The post has been deleted');
   } catch (error) {
     next(error);
@@ -121,6 +124,9 @@ export const updatepost = async (req, res, next) => {
         },
         { new: true }
     );
+    if (updatedPost) {
+        await indexSearchDocument('post', updatedPost);
+    }
     res.status(200).json(updatedPost);
   } catch (error) {
     next(error);

--- a/api/controllers/problem.controller.js
+++ b/api/controllers/problem.controller.js
@@ -1,6 +1,7 @@
 import Problem from '../models/problem.model.js';
 import { errorHandler } from '../utils/error.js';
 import jwt from 'jsonwebtoken';
+import { indexSearchDocument, removeSearchDocument } from '../services/search.service.js';
 
 const generateSlug = (text = '') =>
     text
@@ -149,6 +150,7 @@ export const createProblem = async (req, res, next) => {
         });
 
         const savedProblem = await problem.save();
+        await indexSearchDocument('problem', savedProblem);
         res.status(201).json(savedProblem);
     } catch (error) {
         next(error);
@@ -283,6 +285,7 @@ export const updateProblem = async (req, res, next) => {
             return next(errorHandler(404, 'Problem not found.'));
         }
 
+        await indexSearchDocument('problem', updatedProblem);
         res.status(200).json(updatedProblem);
     } catch (error) {
         next(error);
@@ -296,6 +299,7 @@ export const deleteProblem = async (req, res, next) => {
 
     try {
         await Problem.findByIdAndDelete(req.params.problemId);
+        await removeSearchDocument('problem', req.params.problemId);
         res.status(200).json('The problem has been deleted');
     } catch (error) {
         next(error);

--- a/api/controllers/search.controller.js
+++ b/api/controllers/search.controller.js
@@ -1,0 +1,151 @@
+import Post from '../models/post.model.js';
+import Tutorial from '../models/tutorial.model.js';
+import Problem from '../models/problem.model.js';
+import { errorHandler } from '../utils/error.js';
+import {
+    SUPPORTED_SEARCH_TYPES,
+    bulkReplaceDocuments,
+    isSearchEnabled,
+    searchDocuments,
+    toSearchResult,
+} from '../services/search.service.js';
+
+const parseTypes = (typesParam) => {
+    if (!typesParam) return [];
+    return typesParam
+        .split(',')
+        .map((type) => type.trim().toLowerCase())
+        .filter((type) => SUPPORTED_SEARCH_TYPES.includes(type));
+};
+
+const fallbackSearch = async ({ term, limit, sort, types }) => {
+    const regex = new RegExp(term, 'i');
+    const searchTypes = types.length ? types : SUPPORTED_SEARCH_TYPES;
+    const perTypeLimit = Math.max(3, Math.ceil(limit / searchTypes.length));
+    const resultBuckets = [];
+
+    for (const type of searchTypes) {
+        if (type === 'post') {
+            const docs = await Post.find({
+                $or: [
+                    { title: { $regex: regex } },
+                    { content: { $regex: regex } },
+                ],
+            })
+                .sort(sort === 'recent' ? { updatedAt: -1 } : { createdAt: -1 })
+                .limit(perTypeLimit)
+                .lean();
+            resultBuckets.push(...docs.map((doc) => toSearchResult('post', doc)).filter(Boolean));
+        } else if (type === 'tutorial') {
+            const docs = await Tutorial.find({
+                $or: [
+                    { title: { $regex: regex } },
+                    { description: { $regex: regex } },
+                    { 'chapters.content': { $regex: regex } },
+                ],
+            })
+                .sort(sort === 'recent' ? { updatedAt: -1 } : { createdAt: -1 })
+                .limit(perTypeLimit)
+                .lean();
+            resultBuckets.push(...docs.map((doc) => toSearchResult('tutorial', doc)).filter(Boolean));
+        } else if (type === 'problem') {
+            const docs = await Problem.find({
+                $or: [
+                    { title: { $regex: regex } },
+                    { description: { $regex: regex } },
+                    { statement: { $regex: regex } },
+                ],
+            })
+                .sort(sort === 'recent' ? { updatedAt: -1 } : { createdAt: -1 })
+                .limit(perTypeLimit)
+                .lean();
+            resultBuckets.push(...docs.map((doc) => toSearchResult('problem', doc)).filter(Boolean));
+        }
+    }
+
+    const sortedResults = sort === 'recent'
+        ? resultBuckets.sort((a, b) => new Date(b.updatedAt || b.createdAt || 0) - new Date(a.updatedAt || a.createdAt || 0))
+        : resultBuckets;
+
+    return {
+        query: term,
+        total: sortedResults.length,
+        took: null,
+        results: sortedResults.slice(0, limit),
+        fallbackUsed: true,
+        message: 'Elasticsearch is not configured. Results are provided via a MongoDB fallback search.',
+    };
+};
+
+export const globalSearch = async (req, res, next) => {
+    const searchTerm = (req.query.q || req.query.searchTerm || '').toString().trim();
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 20, 1), 100);
+    const sort = req.query.sort === 'recent' ? 'recent' : 'relevance';
+    const types = parseTypes(req.query.types);
+
+    if (!searchTerm) {
+        return res.status(200).json({
+            query: '',
+            total: 0,
+            took: null,
+            results: [],
+            fallbackUsed: !isSearchEnabled(),
+        });
+    }
+
+    try {
+        if (isSearchEnabled()) {
+            const data = await searchDocuments({ term: searchTerm, limit, sort, types });
+            return res.status(200).json({
+                ...data,
+                sort,
+                types: types.length ? types : SUPPORTED_SEARCH_TYPES,
+                fallbackUsed: false,
+            });
+        }
+
+        const fallbackData = await fallbackSearch({ term: searchTerm, limit, sort, types });
+        return res.status(200).json({
+            ...fallbackData,
+            sort,
+            types: types.length ? types : SUPPORTED_SEARCH_TYPES,
+        });
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const reindexSearchContent = async (req, res, next) => {
+    if (!req.user?.isAdmin) {
+        return next(errorHandler(403, 'Only administrators can reindex search content.'));
+    }
+
+    if (!isSearchEnabled()) {
+        return next(errorHandler(503, 'Elasticsearch is not configured.'));
+    }
+
+    try {
+        const [posts, tutorials, problems] = await Promise.all([
+            Post.find({}).lean(),
+            Tutorial.find({}).lean(),
+            Problem.find({}).lean(),
+        ]);
+
+        const [postResult, tutorialResult, problemResult] = await Promise.all([
+            bulkReplaceDocuments('post', posts),
+            bulkReplaceDocuments('tutorial', tutorials),
+            bulkReplaceDocuments('problem', problems),
+        ]);
+
+        res.status(200).json({
+            success: true,
+            indexed: {
+                posts: postResult.indexed,
+                tutorials: tutorialResult.indexed,
+                problems: problemResult.indexed,
+            },
+        });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/api/controllers/tutorial.controller.js
+++ b/api/controllers/tutorial.controller.js
@@ -1,5 +1,6 @@
 import Tutorial from '../models/tutorial.model.js';
 import { errorHandler } from '../utils/error.js';
+import { indexSearchDocument, removeSearchDocument } from '../services/search.service.js';
 
 const generateSlug = (text) => {
     return text
@@ -40,6 +41,7 @@ export const createTutorial = async (req, res, next) => {
 
     try {
         const savedTutorial = await newTutorial.save();
+        await indexSearchDocument('tutorial', savedTutorial);
         res.status(201).json(savedTutorial);
     } catch (error) {
         console.error('Error saving new tutorial:', error);
@@ -119,6 +121,7 @@ export const updateTutorial = async (req, res, next) => {
         if (!updatedTutorial) {
             return next(errorHandler(404, 'Tutorial not found'));
         }
+        await indexSearchDocument('tutorial', updatedTutorial);
         res.status(200).json(updatedTutorial);
     } catch (error) {
         next(error);
@@ -131,6 +134,7 @@ export const deleteTutorial = async (req, res, next) => {
     }
     try {
         await Tutorial.findByIdAndDelete(req.params.tutorialId);
+        await removeSearchDocument('tutorial', req.params.tutorialId);
         res.status(200).json('The tutorial has been deleted');
     } catch (error) {
         next(error);
@@ -177,6 +181,7 @@ export const addChapter = async (req, res, next) => {
         tutorial.chapters.push(chapterData);
         tutorial.chapters.sort((a, b) => a.order - b.order);
         await tutorial.save();
+        await indexSearchDocument('tutorial', tutorial);
         res.status(201).json(tutorial.chapters[tutorial.chapters.length - 1]);
     } catch (error) {
         console.error('Error adding new chapter:', error);
@@ -217,6 +222,7 @@ export const updateChapter = async (req, res, next) => {
 
         tutorial.chapters.sort((a, b) => a.order - b.order);
         await tutorial.save();
+        await indexSearchDocument('tutorial', tutorial);
         res.status(200).json(chapter);
     } catch (error) {
         next(error);
@@ -235,6 +241,7 @@ export const deleteChapter = async (req, res, next) => {
 
         tutorial.chapters.pull({ _id: req.params.chapterId });
         await tutorial.save();
+        await indexSearchDocument('tutorial', tutorial);
         res.status(200).json('Chapter deleted successfully');
     } catch (error) {
         next(error);

--- a/api/index.js
+++ b/api/index.js
@@ -16,6 +16,7 @@ import javaRoutes from './routes/java.route.js';
 import csharpRoutes from './routes/csharp.route.js';
 import pageRoutes from './routes/page.route.js';
 import problemRoutes from './routes/problem.route.js';
+import searchRoutes from './routes/search.route.js';
 
 import cookieParser from 'cookie-parser';
 import path from 'path';
@@ -84,6 +85,7 @@ app.use('/api/code', javascriptRoutes);
 app.use('/api/code', javaRoutes);
 app.use('/api/code', csharpRoutes);
 app.use('/api', pageRoutes);
+app.use('/api/search', searchRoutes);
 
 app.use(express.static(path.join(__dirname, '/client/dist')));
 

--- a/api/routes/search.route.js
+++ b/api/routes/search.route.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { globalSearch, reindexSearchContent } from '../controllers/search.controller.js';
+import { verifyToken } from '../utils/verifyUser.js';
+
+const router = express.Router();
+
+router.get('/', globalSearch);
+router.post('/reindex', verifyToken, reindexSearchContent);
+
+export default router;

--- a/api/services/search.service.js
+++ b/api/services/search.service.js
@@ -1,0 +1,380 @@
+import { Buffer } from 'node:buffer';
+
+const {
+    ELASTICSEARCH_NODE,
+    ELASTICSEARCH_USERNAME,
+    ELASTICSEARCH_PASSWORD,
+    ELASTICSEARCH_API_KEY,
+    ELASTICSEARCH_INDEX_PREFIX = 'scientistshield',
+} = process.env;
+
+const BASE_URL = ELASTICSEARCH_NODE
+    ? ELASTICSEARCH_NODE.endsWith('/')
+        ? ELASTICSEARCH_NODE
+        : `${ELASTICSEARCH_NODE}/`
+    : null;
+
+const SUPPORTED_TYPES = ['post', 'tutorial', 'problem'];
+
+const buildHeaders = (customHeaders = {}) => {
+    const headers = { ...customHeaders };
+
+    if (!headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json';
+    }
+
+    if (ELASTICSEARCH_API_KEY) {
+        headers.Authorization = `ApiKey ${ELASTICSEARCH_API_KEY}`;
+    } else if (ELASTICSEARCH_USERNAME && ELASTICSEARCH_PASSWORD) {
+        const token = Buffer.from(
+            `${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}`
+        ).toString('base64');
+        headers.Authorization = `Basic ${token}`;
+    }
+
+    return headers;
+};
+
+const request = async (path, { method = 'GET', headers = {}, body, signal } = {}) => {
+    if (!BASE_URL) {
+        throw new Error('Elasticsearch is not configured');
+    }
+
+    const url = new URL(path.startsWith('/') ? path.slice(1) : path, BASE_URL);
+    const response = await fetch(url, {
+        method,
+        headers: buildHeaders(headers),
+        body,
+        signal,
+    });
+
+    if (!response.ok) {
+        const errorPayload = await response.text();
+        throw new Error(
+            `Elasticsearch request failed: ${response.status} ${response.statusText} - ${errorPayload}`
+        );
+    }
+
+    if (response.status === 204) {
+        return null;
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+        return response.json();
+    }
+
+    return response.text();
+};
+
+export const isSearchEnabled = () => Boolean(BASE_URL);
+
+const stripHtml = (value = '') =>
+    value
+        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
+        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
+        .replace(/<[^>]*>/g, ' ')
+        .replace(/&[a-z]+;/gi, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+const createSummary = (text = '', maxLength = 280) => {
+    const sanitized = stripHtml(text);
+    if (sanitized.length <= maxLength) {
+        return sanitized;
+    }
+    const truncated = sanitized.slice(0, maxLength);
+    return `${truncated.replace(/[.,;:\s]+$/, '')}…`;
+};
+
+const toArrayOfStrings = (value) => {
+    if (!value) return [];
+    if (Array.isArray(value)) {
+        return value
+            .map((item) => (item == null ? null : String(item)))
+            .filter(Boolean);
+    }
+    return [String(value)];
+};
+
+const normalizeDocument = (type, document) => {
+    if (!SUPPORTED_TYPES.includes(type) || !document) {
+        return null;
+    }
+
+    const plain =
+        typeof document.toObject === 'function'
+            ? document.toObject({ depopulate: true })
+            : document;
+
+    const id = plain?._id?.toString();
+    if (!id) {
+        return null;
+    }
+
+    const base = {
+        id,
+        type,
+        title: plain.title || '',
+        slug: plain.slug || '',
+        category: plain.category || '',
+        createdAt: plain.createdAt ? new Date(plain.createdAt).toISOString() : null,
+        updatedAt: plain.updatedAt ? new Date(plain.updatedAt).toISOString() : null,
+    };
+
+    if (type === 'post') {
+        const content = stripHtml(plain.content || '');
+        return {
+            ...base,
+            summary: createSummary(plain.content || plain.title || ''),
+            content,
+            authorId: plain.userId ? String(plain.userId) : null,
+            tags: [],
+            topics: [],
+            companies: [],
+        };
+    }
+
+    if (type === 'tutorial') {
+        const chapterContent = (plain.chapters || [])
+            .flatMap((chapter) => {
+                const chapterPieces = [chapter.chapterTitle, chapter.content];
+                const nested = (chapter.subChapters || []).map((sub) => `${sub.chapterTitle} ${sub.content}`);
+                return [...chapterPieces, ...nested];
+            })
+            .filter(Boolean)
+            .join(' ');
+
+        const combinedContent = [plain.description, chapterContent].filter(Boolean).join(' ');
+
+        return {
+            ...base,
+            summary: createSummary(plain.description || combinedContent || plain.title || ''),
+            content: stripHtml(combinedContent),
+            tags: [],
+            topics: [],
+            companies: [],
+            difficulty: plain.difficulty || null,
+        };
+    }
+
+    if (type === 'problem') {
+        const combinedContent = [
+            plain.description,
+            plain.statement,
+            plain.solutionApproach,
+            plain.editorial,
+            ...(plain.constraints || []),
+            ...(plain.hints || []),
+        ]
+            .filter(Boolean)
+            .join(' ');
+
+        return {
+            ...base,
+            summary: createSummary(plain.description || plain.statement || plain.title || ''),
+            content: stripHtml(combinedContent),
+            tags: toArrayOfStrings(plain.tags),
+            topics: toArrayOfStrings(plain.topics),
+            companies: toArrayOfStrings(plain.companies),
+            difficulty: plain.difficulty || null,
+        };
+    }
+
+    return null;
+};
+
+const buildIndexName = (type) => `${ELASTICSEARCH_INDEX_PREFIX}-${type}`;
+
+const serializeDocument = (type, document) => {
+    const normalized = normalizeDocument(type, document);
+    if (!normalized) {
+        return null;
+    }
+    const { id, ...body } = normalized;
+    return {
+        index: buildIndexName(type),
+        id,
+        body,
+    };
+};
+
+export const toSearchResult = (type, document) => {
+    const normalized = normalizeDocument(type, document);
+    if (!normalized) {
+        return null;
+    }
+    const { content, ...rest } = normalized;
+    return rest;
+};
+
+export const indexSearchDocument = async (type, document) => {
+    if (!isSearchEnabled()) {
+        return false;
+    }
+    const payload = serializeDocument(type, document);
+    if (!payload) {
+        return false;
+    }
+
+    try {
+        await request(`/${payload.index}/_doc/${payload.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(payload.body),
+        });
+        return true;
+    } catch (error) {
+        console.warn(`Failed to index ${type} ${payload.id}:`, error.message);
+        return false;
+    }
+};
+
+export const removeSearchDocument = async (type, id) => {
+    if (!isSearchEnabled() || !SUPPORTED_TYPES.includes(type) || !id) {
+        return false;
+    }
+
+    try {
+        await request(`/${buildIndexName(type)}/_doc/${id}`, { method: 'DELETE' });
+        return true;
+    } catch (error) {
+        if (!/404/.test(error.message)) {
+            console.warn(`Failed to remove ${type} ${id} from search index:`, error.message);
+        }
+        return false;
+    }
+};
+
+const mapSearchHit = (hit) => {
+    const source = hit?._source || {};
+    const highlight = hit?.highlight
+        ? Object.values(hit.highlight).flat().map((snippet) => String(snippet))
+        : [];
+
+    return {
+        id: hit?._id,
+        type: source.type || null,
+        title: source.title || '',
+        slug: source.slug || '',
+        summary: source.summary || '',
+        category: source.category || '',
+        tags: source.tags || [],
+        topics: source.topics || [],
+        companies: source.companies || [],
+        difficulty: source.difficulty || null,
+        createdAt: source.createdAt || null,
+        updatedAt: source.updatedAt || null,
+        score: hit?._score ?? null,
+        highlight,
+    };
+};
+
+export const searchDocuments = async ({ term, limit = 20, sort = 'relevance', types = [] }) => {
+    if (!isSearchEnabled()) {
+        throw new Error('Elasticsearch is not configured');
+    }
+
+    const queryTypes = types.length
+        ? types.filter((type) => SUPPORTED_TYPES.includes(type))
+        : SUPPORTED_TYPES;
+
+    const indexPattern = queryTypes.map((type) => buildIndexName(type)).join(',');
+
+    const payload = {
+        size: Math.min(Math.max(limit, 1), 100),
+        query: {
+            bool: {
+                must: [
+                    {
+                        multi_match: {
+                            query: term,
+                            fields: [
+                                'title^3',
+                                'summary^2',
+                                'content',
+                                'tags',
+                                'topics',
+                                'companies',
+                            ],
+                            type: 'best_fields',
+                            operator: 'and',
+                        },
+                    },
+                ],
+            },
+        },
+        highlight: {
+            pre_tags: ['<mark>'],
+            post_tags: ['</mark>'],
+            fields: {
+                content: {},
+                summary: {},
+                title: {},
+            },
+        },
+    };
+
+    if (sort === 'recent') {
+        payload.sort = [{ updatedAt: { order: 'desc' } }];
+    } else {
+        payload.sort = [{ _score: { order: 'desc' } }];
+    }
+
+    const response = await request(`/${indexPattern}/_search`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+
+    const hits = response?.hits?.hits || [];
+    const totalValue = typeof response?.hits?.total?.value === 'number'
+        ? response.hits.total.value
+        : hits.length;
+
+    return {
+        query: term,
+        total: totalValue,
+        took: response?.took ?? null,
+        results: hits.map(mapSearchHit),
+    };
+};
+
+export const bulkReplaceDocuments = async (type, documents = []) => {
+    if (!isSearchEnabled() || !SUPPORTED_TYPES.includes(type)) {
+        return { indexed: 0, skipped: documents.length };
+    }
+
+    const indexName = buildIndexName(type);
+
+    try {
+        await request(`/${indexName}`, { method: 'DELETE' });
+    } catch (error) {
+        if (!/404/.test(error.message)) {
+            console.warn(`Failed to reset index ${indexName}:`, error.message);
+        }
+    }
+
+    const operations = documents
+        .map((document) => serializeDocument(type, document))
+        .filter(Boolean)
+        .flatMap((payload) => [
+            JSON.stringify({ index: { _index: payload.index, _id: payload.id } }),
+            JSON.stringify(payload.body),
+        ]);
+
+    if (operations.length === 0) {
+        return { indexed: 0, skipped: documents.length };
+    }
+
+    await request('/_bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-ndjson' },
+        body: `${operations.join('\n')}\n`,
+    });
+
+    return {
+        indexed: operations.length / 2,
+        skipped: documents.length - operations.length / 2,
+    };
+};
+
+export const SUPPORTED_SEARCH_TYPES = [...SUPPORTED_TYPES];

--- a/client/src/pages/Search.jsx
+++ b/client/src/pages/Search.jsx
@@ -1,122 +1,323 @@
-import { Button, Select, TextInput, Spinner } from 'flowbite-react';
-import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import PostCard from '../components/PostCard';
-import { usePostSearch } from '../hooks/usePostSearch'; // <-- Import the custom hook
+import { Button, Select, Spinner, TextInput, Badge } from 'flowbite-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { getSearchResults } from '../services/searchService';
+
+const TYPE_OPTIONS = [
+    { value: 'all', label: 'All content' },
+    { value: 'post', label: 'Posts' },
+    { value: 'tutorial', label: 'Tutorials' },
+    { value: 'problem', label: 'Problems' },
+];
+
+const SORT_OPTIONS = [
+    { value: 'relevance', label: 'Best match' },
+    { value: 'recent', label: 'Most recent' },
+];
+
+const TYPE_LABELS = {
+    post: 'Post',
+    tutorial: 'Tutorial',
+    problem: 'Problem',
+};
+
+const buildResultPath = (result) => {
+    switch (result.type) {
+        case 'post':
+            return `/post/${result.slug}`;
+        case 'tutorial':
+            return `/tutorials/${result.slug}`;
+        case 'problem':
+            return `/problems/${result.slug}`;
+        default:
+            return '#';
+    }
+};
+
+const formatDate = (value) => {
+    if (!value) return null;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    return date.toLocaleDateString();
+};
 
 export default function Search() {
-  const [sidebarData, setSidebarData] = useState({
-    searchTerm: '',
-    sort: 'desc',
-    category: 'uncategorized',
-  });
+    const location = useLocation();
+    const navigate = useNavigate();
 
-  // 1. All logic for fetching and managing posts is now in the hook
-  const { posts, loading, showMore, error, fetchMorePosts } = usePostSearch();
-
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  // 2. This effect syncs the URL to the form state on initial load/navigation
-  useEffect(() => {
-    const urlParams = new URLSearchParams(location.search);
-    const searchTermFromUrl = urlParams.get('searchTerm') || '';
-    const sortFromUrl = urlParams.get('sort') || 'desc';
-    const categoryFromUrl = urlParams.get('category') || 'uncategorized';
-
-    setSidebarData({
-      searchTerm: searchTermFromUrl,
-      sort: sortFromUrl,
-      category: categoryFromUrl,
+    const [sidebarData, setSidebarData] = useState({
+        searchTerm: '',
+        sort: 'relevance',
+        contentType: 'all',
     });
-  }, [location.search]);
+    const [results, setResults] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [metadata, setMetadata] = useState({ total: 0, took: null, fallbackUsed: false, message: null });
 
-  // 3. The form handlers remain, as they are part of the UI component's responsibility
-  const handleChange = (e) => {
-    const { id, value } = e.target;
-    setSidebarData({ ...sidebarData, [id]: value });
-  };
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        const searchTermFromUrl = params.get('searchTerm') || '';
+        const sortFromUrl = params.get('sort') || 'relevance';
+        const typeFromUrl = params.get('types') || 'all';
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    const urlParams = new URLSearchParams(location.search);
-    urlParams.set('searchTerm', sidebarData.searchTerm);
-    urlParams.set('sort', sidebarData.sort);
-    urlParams.set('category', sidebarData.category);
-    const searchQuery = urlParams.toString();
-    navigate(`/search?${searchQuery}`);
-  };
+        setSidebarData({
+            searchTerm: searchTermFromUrl,
+            sort: SORT_OPTIONS.some((option) => option.value === sortFromUrl) ? sortFromUrl : 'relevance',
+            contentType: TYPE_OPTIONS.some((option) => option.value === typeFromUrl) ? typeFromUrl : 'all',
+        });
+    }, [location.search]);
 
-  return (
-      <div className='flex flex-col md:flex-row'>
-        <div className='p-7 border-b md:border-r md:min-h-screen border-gray-500'>
-          <form className='flex flex-col gap-8' onSubmit={handleSubmit}>
-            {/* Form inputs are now cleaner */}
-            <div className='flex items-center gap-2'>
-              <label className='whitespace-nowrap font-semibold'>Search Term:</label>
-              <TextInput
-                  placeholder='Search...'
-                  id='searchTerm'
-                  type='text'
-                  value={sidebarData.searchTerm}
-                  onChange={handleChange}
-              />
-            </div>
-            <div className='flex items-center gap-2'>
-              <label className='font-semibold'>Sort:</label>
-              <Select onChange={handleChange} value={sidebarData.sort} id='sort'>
-                <option value='desc'>Latest</option>
-                <option value='asc'>Oldest</option>
-              </Select>
-            </div>
-            <div className='flex items-center gap-2'>
-              <label className='font-semibold'>Category:</label>
-              <Select
-                  onChange={handleChange}
-                  value={sidebarData.category}
-                  id='category'
-              >
-                <option value='uncategorized'>Uncategorized</option>
-                <option value='reactjs'>React.js</option>
-                <option value='nextjs'>Next.js</option>
-                <option value='javascript'>JavaScript</option>
-              </Select>
-            </div>
-            <Button type='submit' outline gradientDuoTone='purpleToPink'>
-              Apply Filters
-            </Button>
-          </form>
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        const searchTerm = params.get('searchTerm') || '';
+
+        if (!searchTerm.trim()) {
+            setResults([]);
+            setMetadata({ total: 0, took: null, fallbackUsed: false, message: null });
+            setError(null);
+            return () => {};
+        }
+
+        const controller = new AbortController();
+        const contentType = params.get('types') || 'all';
+        const sort = params.get('sort') || 'relevance';
+
+        const query = {
+            searchTerm,
+            sort,
+            limit: 25,
+        };
+
+        if (contentType && contentType !== 'all') {
+            query.types = contentType;
+        }
+
+        setLoading(true);
+        setError(null);
+
+        getSearchResults(query, { signal: controller.signal })
+            .then((data) => {
+                setResults(Array.isArray(data.results) ? data.results : []);
+                setMetadata({
+                    total: data.total ?? 0,
+                    took: data.took ?? null,
+                    fallbackUsed: Boolean(data.fallbackUsed),
+                    message: data.message || null,
+                });
+            })
+            .catch((err) => {
+                if (err.name === 'AbortError') return;
+                setError(err.message || 'Unable to fetch search results.');
+                setResults([]);
+                setMetadata({ total: 0, took: null, fallbackUsed: false, message: null });
+            })
+            .finally(() => {
+                setLoading(false);
+            });
+
+        return () => controller.abort();
+    }, [location.search]);
+
+    const handleChange = (event) => {
+        const { id, value } = event.target;
+        setSidebarData((prev) => ({ ...prev, [id]: value }));
+    };
+
+    const handleSubmit = (event) => {
+        event.preventDefault();
+        const params = new URLSearchParams();
+
+        if (sidebarData.searchTerm.trim()) {
+            params.set('searchTerm', sidebarData.searchTerm.trim());
+        }
+
+        if (sidebarData.sort !== 'relevance') {
+            params.set('sort', sidebarData.sort);
+        }
+
+        if (sidebarData.contentType !== 'all') {
+            params.set('types', sidebarData.contentType);
+        }
+
+        navigate({ pathname: '/search', search: params.toString() });
+    };
+
+    const handleClear = () => {
+        setSidebarData({ searchTerm: '', sort: 'relevance', contentType: 'all' });
+        navigate('/search');
+    };
+
+    const headerMeta = useMemo(() => {
+        if (!sidebarData.searchTerm.trim()) {
+            return 'Start typing to search across posts, tutorials, and coding problems.';
+        }
+
+        if (loading) {
+            return 'Searching across the knowledge base…';
+        }
+
+        if (error) {
+            return error;
+        }
+
+        const pieces = [];
+        pieces.push(`${metadata.total} result${metadata.total === 1 ? '' : 's'}`);
+        if (metadata.took != null) {
+            pieces.push(`${metadata.took} ms`);
+        }
+        if (metadata.fallbackUsed) {
+            pieces.push('MongoDB fallback');
+        }
+        return pieces.join(' · ');
+    }, [sidebarData.searchTerm, loading, error, metadata]);
+
+    return (
+        <div className='flex flex-col md:flex-row'>
+            <aside className='p-7 border-b md:border-r md:min-h-screen border-gray-500 w-full md:w-80'>
+                <form className='flex flex-col gap-6' onSubmit={handleSubmit}>
+                    <div className='flex items-center gap-2'>
+                        <label className='whitespace-nowrap font-semibold' htmlFor='searchTerm'>
+                            Search term
+                        </label>
+                        <TextInput
+                            id='searchTerm'
+                            placeholder='Try "dynamic programming"'
+                            type='search'
+                            value={sidebarData.searchTerm}
+                            onChange={handleChange}
+                        />
+                    </div>
+                    <div className='flex items-center gap-2'>
+                        <label className='font-semibold' htmlFor='contentType'>
+                            Content type
+                        </label>
+                        <Select id='contentType' value={sidebarData.contentType} onChange={handleChange}>
+                            {TYPE_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+                    <div className='flex items-center gap-2'>
+                        <label className='font-semibold' htmlFor='sort'>
+                            Sort by
+                        </label>
+                        <Select id='sort' value={sidebarData.sort} onChange={handleChange}>
+                            {SORT_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </Select>
+                    </div>
+                    <div className='flex items-center gap-3'>
+                        <Button type='submit' gradientDuoTone='purpleToPink' className='flex-1'>
+                            Update results
+                        </Button>
+                        <Button type='button' color='light' onClick={handleClear}>
+                            Clear
+                        </Button>
+                    </div>
+                </form>
+            </aside>
+            <main className='w-full'>
+                <header className='border-b border-gray-500 p-7 flex flex-col gap-2'>
+                    <h1 className='text-3xl font-semibold'>Search results</h1>
+                    <p className='text-sm text-gray-500 dark:text-gray-400'>{headerMeta}</p>
+                    {metadata.message && (
+                        <p className='text-xs text-amber-600 dark:text-amber-400'>{metadata.message}</p>
+                    )}
+                </header>
+                <section className='p-7 flex flex-col gap-4'>
+                    {loading && (
+                        <div className='flex justify-center items-center py-12'>
+                            <Spinner size='xl' />
+                        </div>
+                    )}
+
+                    {!loading && !error && results.length === 0 && sidebarData.searchTerm.trim() && (
+                        <p className='text-lg text-gray-500 dark:text-gray-400'>
+                            No matching content yet. Try a different keyword or expand the content filter.
+                        </p>
+                    )}
+
+                    {!loading && !sidebarData.searchTerm.trim() && (
+                        <p className='text-lg text-gray-500 dark:text-gray-400'>
+                            Use the filters on the left to discover posts, tutorials, and coding problems instantly.
+                        </p>
+                    )}
+
+                    {!loading && !error && (
+                        <div className='flex flex-col gap-3'>
+                            {results.map((result) => {
+                                const path = buildResultPath(result);
+                                const snippet = result.highlight?.[0] || result.summary;
+                                const updated = formatDate(result.updatedAt || result.createdAt);
+
+                                return (
+                                    <Link
+                                        key={`${result.type}-${result.id}`}
+                                        to={path}
+                                        className='block rounded-lg border border-gray-200 dark:border-gray-700 p-5 hover:border-purple-400 dark:hover:border-purple-400 transition-colors'
+                                    >
+                                        <div className='flex flex-col gap-3'>
+                                            <div className='flex items-center gap-3 justify-between'>
+                                                <Badge color='indigo' size='sm'>
+                                                    {TYPE_LABELS[result.type] || 'Content'}
+                                                </Badge>
+                                                {updated && (
+                                                    <span className='text-xs text-gray-500 dark:text-gray-400'>
+                                                        Updated {updated}
+                                                    </span>
+                                                )}
+                                            </div>
+                                            <h2 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+                                                {result.title}
+                                            </h2>
+                                            {snippet && (
+                                                <p
+                                                    className='text-sm text-gray-600 dark:text-gray-300'
+                                                    dangerouslySetInnerHTML={{ __html: snippet }}
+                                                />
+                                            )}
+                                            <div className='flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400'>
+                                                {result.category && (
+                                                    <span className='px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800'>
+                                                        {result.category}
+                                                    </span>
+                                                )}
+                                                {result.difficulty && (
+                                                    <span className='px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800'>
+                                                        Difficulty: {result.difficulty}
+                                                    </span>
+                                                )}
+                                                {result.topics?.slice(0, 3).map((topic) => (
+                                                    <span key={topic} className='px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800'>
+                                                        {topic}
+                                                    </span>
+                                                ))}
+                                                {result.tags?.slice(0, 3).map((tag) => (
+                                                    <span key={tag} className='px-2 py-1 rounded-full bg-gray-100 dark:bg-gray-800'>
+                                                        #{tag}
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    </Link>
+                                );
+                            })}
+                        </div>
+                    )}
+
+                    {!loading && error && (
+                        <p className='text-lg text-red-500'>{error}</p>
+                    )}
+                </section>
+            </main>
         </div>
-        <div className='w-full'>
-          <h1 className='text-3xl font-semibold sm:border-b border-gray-500 p-3 mt-5'>
-            Posts results:
-          </h1>
-          <div className='p-7 flex flex-wrap gap-4'>
-            {/* 4. The rendering logic is much simpler and more declarative */}
-            {loading && (
-                <div className="flex justify-center items-center w-full">
-                  <Spinner size="xl" />
-                </div>
-            )}
-            {!loading && error && (
-                <p className='text-xl text-gray-500'>{error}</p>
-            )}
-            {!loading && posts.length === 0 && !error && (
-                <p className='text-xl text-gray-500'>No posts found.</p>
-            )}
-            {!loading &&
-                posts.map((post) => <PostCard key={post._id} post={post} />)}
-
-            {showMore && (
-                <button
-                    onClick={fetchMorePosts}
-                    className='text-teal-500 text-lg hover:underline p-7 w-full'
-                >
-                  Show More
-                </button>
-            )}
-          </div>
-        </div>
-      </div>
-  );
+    );
 }

--- a/client/src/services/searchService.js
+++ b/client/src/services/searchService.js
@@ -1,0 +1,30 @@
+export const getSearchResults = async (params = {}, options = {}) => {
+    const searchParams = new URLSearchParams();
+
+    if (params.searchTerm) {
+        searchParams.set('searchTerm', params.searchTerm);
+    }
+
+    if (params.types) {
+        searchParams.set('types', params.types);
+    }
+
+    if (params.limit) {
+        searchParams.set('limit', String(params.limit));
+    }
+
+    if (params.sort) {
+        searchParams.set('sort', params.sort);
+    }
+
+    const queryString = searchParams.toString();
+    const url = queryString ? `/api/search?${queryString}` : '/api/search';
+
+    const res = await fetch(url, { signal: options.signal });
+    if (!res.ok) {
+        const { message } = await res.json().catch(() => ({ message: 'Failed to fetch search results' }));
+        throw new Error(message || 'Failed to fetch search results');
+    }
+
+    return res.json();
+};


### PR DESCRIPTION
## Summary
- add a reusable search service that speaks to Elasticsearch with graceful MongoDB fallback
- index posts, tutorials, and problems on write operations and expose new `/api/search` + `/api/search/reindex` endpoints
- redesign the client search page to query the new API and surface cross-content results with metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd45361b4c83269920bcdcc75b4a50