### PR TITLE
Enhance search filters with multi-select options

### DIFF
--- a/client/src/services/searchService.js
+++ b/client/src/services/searchService.js
@@ -6,7 +6,14 @@ export const getSearchResults = async (params = {}, options = {}) => {
     }
 
     if (params.types) {
-        searchParams.set('types', params.types);
+        if (Array.isArray(params.types)) {
+            const filteredTypes = params.types.map((type) => type.trim()).filter(Boolean);
+            if (filteredTypes.length) {
+                searchParams.set('types', filteredTypes.join(','));
+            }
+        } else if (typeof params.types === 'string' && params.types.trim()) {
+            searchParams.set('types', params.types.trim());
+        }
     }
 
     if (params.limit) {


### PR DESCRIPTION
## Summary
- replace the single content-type dropdown on the search page with descriptive checkboxes and filter badges
- ensure URL parsing, state management, and API requests support multiple selected content types when searching
- allow the search service helper to accept either arrays or strings when serializing type filters

## Testing
- npm run build --prefix client

------
https://chatgpt.com/codex/tasks/task_b_68ddf9ba64fc832684f32fe4f1059959