### PR TITLE
Add centralized error boundary handling

### DIFF
--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import reportError from '../utils/reportError.js';
+
+const DefaultFallback = ({ error, resetErrorBoundary }) => (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-slate-950 text-slate-100 px-6 text-center">
+        <div className="max-w-lg space-y-4">
+            <h1 className="text-3xl font-semibold">Something went wrong</h1>
+            <p className="text-slate-300">
+                An unexpected error occurred while rendering this page. Our team has been notified.
+                You can try again or return to the previous page.
+            </p>
+            {error?.message && (
+                <pre className="mt-4 whitespace-pre-wrap break-words rounded-lg bg-slate-900/70 p-4 text-sm text-rose-300 shadow-inner">
+                    {error.message}
+                </pre>
+            )}
+            <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                <button
+                    type="button"
+                    onClick={resetErrorBoundary}
+                    className="rounded-md bg-emerald-500 px-4 py-2 text-sm font-medium text-white shadow transition hover:bg-emerald-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+                >
+                    Try again
+                </button>
+                <button
+                    type="button"
+                    onClick={() => window.location.assign('/')}
+                    className="rounded-md border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-500 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+                >
+                    Go home
+                </button>
+            </div>
+        </div>
+    </div>
+);
+
+DefaultFallback.propTypes = {
+    error: PropTypes.instanceOf(Error),
+    resetErrorBoundary: PropTypes.func.isRequired,
+};
+
+DefaultFallback.defaultProps = {
+    error: null,
+};
+
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false, error: null };
+        this.resetErrorBoundary = this.resetErrorBoundary.bind(this);
+    }
+
+    static getDerivedStateFromError(error) {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error, errorInfo) {
+        const { onError } = this.props;
+        const reporter = typeof onError === 'function' ? onError : reportError;
+
+        reporter(error, errorInfo);
+    }
+
+    resetErrorBoundary() {
+        if (typeof this.props.onReset === 'function') {
+            this.props.onReset();
+        }
+
+        this.setState({ hasError: false, error: null });
+    }
+
+    render() {
+        const { fallback, children } = this.props;
+        const { hasError, error } = this.state;
+
+        if (hasError) {
+            if (typeof fallback === 'function') {
+                return fallback({ error, resetErrorBoundary: this.resetErrorBoundary });
+            }
+
+            if (React.isValidElement(fallback)) {
+                return fallback;
+            }
+
+            return (
+                <DefaultFallback error={error} resetErrorBoundary={this.resetErrorBoundary} />
+            );
+        }
+
+        return children;
+    }
+}
+
+ErrorBoundary.propTypes = {
+    children: PropTypes.node.isRequired,
+    fallback: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+    onError: PropTypes.func,
+    onReset: PropTypes.func,
+};
+
+ErrorBoundary.defaultProps = {
+    fallback: null,
+    onError: undefined,
+    onReset: undefined,
+};
+
+export const withErrorBoundary = (Component, boundaryProps = {}) => {
+    const WrappedComponent = (props) => (
+        <ErrorBoundary {...boundaryProps}>
+            <Component {...props} />
+        </ErrorBoundary>
+    );
+
+    const componentName = Component.displayName || Component.name || 'Component';
+    WrappedComponent.displayName = `withErrorBoundary(${componentName})`;
+
+    return WrappedComponent;
+};
+
+export default ErrorBoundary;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -8,6 +8,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import ThemeProvider from './components/ThemeProvider.jsx';
 import { HelmetProvider } from 'react-helmet-async';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'; // 1. Import
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 
 // 2. Create a client
 const queryClient = new QueryClient();
@@ -18,12 +19,13 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <Provider store={store}>
                 {/* 3. Wrap your app in the provider */}
                 <QueryClientProvider client={queryClient}>
-
-                <HelmetProvider>
-                    <ThemeProvider>
-                        <App />
-                    </ThemeProvider>
-                </HelmetProvider>
+                    <ErrorBoundary onReset={() => queryClient.clear()}>
+                        <HelmetProvider>
+                            <ThemeProvider>
+                                <App />
+                            </ThemeProvider>
+                        </HelmetProvider>
+                    </ErrorBoundary>
                 </QueryClientProvider>
             </Provider>
         </PersistGate>

--- a/client/src/utils/reportError.js
+++ b/client/src/utils/reportError.js
@@ -1,0 +1,51 @@
+const emitBrowserEvent = (name, detail) => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    window.dispatchEvent(new CustomEvent(name, { detail }));
+};
+
+const reportError = (error, errorInfo) => {
+    const payload = {
+        message: error?.message ?? 'Unknown error',
+        stack: error?.stack,
+        componentStack: errorInfo?.componentStack,
+        timestamp: new Date().toISOString(),
+    };
+
+    if (import.meta.env.DEV) {
+        console.error('[ErrorBoundary] A rendering error was captured:', payload);
+        emitBrowserEvent('app:error', payload);
+        return;
+    }
+
+    try {
+        emitBrowserEvent('app:error', payload);
+
+        if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+            const blob = new Blob([JSON.stringify(payload)], { type: 'application/json' });
+            navigator.sendBeacon('/api/client-error', blob);
+            return;
+        }
+
+        if (typeof fetch === 'function') {
+            fetch('/api/client-error', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+                keepalive: true,
+            }).catch(() => {
+                // Silent catch to avoid recursive error handling.
+            });
+        }
+    } catch (loggingError) {
+        if (import.meta.env.DEV) {
+            console.error('[ErrorBoundary] Failed to report error', loggingError);
+        }
+    }
+};
+
+export default reportError;


### PR DESCRIPTION
## Summary
- add a reusable error boundary component with a styled fallback screen and higher-order wrapper
- centralize client-side error reporting logic for future integrations
- wrap the application shell with the new error boundary to gracefully surface rendering issues

## Testing
- npm run lint *(fails: existing lint violations throughout the client codebase)*

------
https://chatgpt.com/codex/tasks/task_b_68df3e686bb883268bc69c48132fda1e