### PR TITLE
Fix relative imports for reading settings context

### DIFF
--- a/client/src/components/InteractiveReadingSurface.jsx
+++ b/client/src/components/InteractiveReadingSurface.jsx
@@ -4,7 +4,7 @@ import parse from 'html-react-parser';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Spinner, Tooltip } from 'flowbite-react';
-import { ReadingSettingsContext } from '../context/ReadingSettingsContext.jsx';
+import { ReadingSettingsContext } from '../context/ReadingSettingsContext';
 import {
     HiOutlineBookOpen,
     HiOutlineX,

--- a/client/src/components/ReadingControlCenter.jsx
+++ b/client/src/components/ReadingControlCenter.jsx
@@ -14,7 +14,7 @@ import {
 import { LuAlignLeft, LuAlignJustify } from 'react-icons/lu';
 import { motion, AnimatePresence, useDragControls } from 'framer-motion';
 import { marginStyleMap } from '../hooks/useReadingSettings';
-import { useReadingSettingsContext } from '../context/ReadingSettingsContext.jsx';
+import { useReadingSettingsContext } from '../context/ReadingSettingsContext';
 
 const themeOptions = [
     { id: 'auto', label: 'Auto', swatch: 'bg-gradient-to-r from-slate-200 via-white to-slate-200', description: 'Follow site theme' },

--- a/client/src/pages/PostPage.jsx
+++ b/client/src/pages/PostPage.jsx
@@ -19,7 +19,7 @@ import SocialShare from '../components/SocialShare';
 import ClapButton from '../components/ClapButton';
 import CodeEditor from '../components/CodeEditor';
 import ReadingControlCenter from '../components/ReadingControlCenter';
-import { ReadingSettingsProvider, useReadingSettingsContext } from '../context/ReadingSettingsContext.jsx';
+import { ReadingSettingsProvider, useReadingSettingsContext } from '../context/ReadingSettingsContext';
 import InteractiveReadingSurface from '../components/InteractiveReadingSurface.jsx';
 import '../Tiptap.css';
 

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -20,7 +20,7 @@ import QuizComponent from '../components/QuizComponent';
 import InteractiveCodeBlock from '../components/InteractiveCodeBlock.jsx';
 import InteractiveReadingSurface from '../components/InteractiveReadingSurface.jsx';
 import ReadingControlCenter from '../components/ReadingControlCenter';
-import { ReadingSettingsProvider, useReadingSettingsContext } from '../context/ReadingSettingsContext.jsx';
+import { ReadingSettingsProvider, useReadingSettingsContext } from '../context/ReadingSettingsContext';
 
 import '../Tiptap.css';
 import '../pages/Scrollbar.css';


### PR DESCRIPTION
## Summary
- update PostPage and SingleTutorialPage to import the reading settings context without specifying the file extension
- align component imports in ReadingControlCenter and InteractiveReadingSurface with the new context path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68df4c5bdc388326b0aef95eb15ac1fd