### PR TITLE
Fix PostPage ReadingSettingsContext import

### DIFF
--- a/client/src/pages/PostPage.jsx
+++ b/client/src/pages/PostPage.jsx
@@ -19,7 +19,7 @@ import SocialShare from '../components/SocialShare';
 import ClapButton from '../components/ClapButton';
 import CodeEditor from '../components/CodeEditor';
 import ReadingControlCenter from '../components/ReadingControlCenter';
-import { ReadingSettingsProvider, useReadingSettingsContext } from '../context/ReadingSettingsContext';
+import { ReadingSettingsProvider, useReadingSettingsContext } from '../context/ReadingSettingsContext.jsx';
 import InteractiveReadingSurface from '../components/InteractiveReadingSurface.jsx';
 import '../Tiptap.css';
 


### PR DESCRIPTION
## Summary
- update the ReadingSettingsContext import in `PostPage` to include the `.jsx` extension so Vite can resolve it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68df50910fe08326a1d2df0f0d89c061